### PR TITLE
Support different types of vals in environment_json

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -18,11 +18,11 @@ type AppResource struct {
 }
 
 type App struct {
-	Guid        string            `json:"guid"`
-	Name        string            `json:"name"`
-	Environment map[string]string `json:"environment_json"`
-	SpaceURL    string            `json:"space_url"`
-	SpaceData   SpaceResource     `json:"space"`
+	Guid        string                 `json:"guid"`
+	Name        string                 `json:"name"`
+	Environment map[string]interface{} `json:"environment_json"`
+	SpaceURL    string                 `json:"space_url"`
+	SpaceData   SpaceResource          `json:"space"`
 	c           *Client
 }
 

--- a/apps_test.go
+++ b/apps_test.go
@@ -38,6 +38,20 @@ func TestAppByGuid(t *testing.T) {
 		So(app.Guid, ShouldEqual, "9902530c-c634-4864-a189-71d763cb12e2")
 		So(app.Name, ShouldEqual, "test-env")
 	})
+
+	Convey("App By GUID with environment variables with different types", t, func() {
+		setup("GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2", appPayloadWithEnvironment_json)
+		defer teardown()
+		c := &Config{
+			ApiAddress:   server.URL,
+			LoginAddress: server.URL,
+			Token:        "foobar",
+		}
+		client := NewClient(c)
+		app := client.AppByGuid("9902530c-c634-4864-a189-71d763cb12e2")
+		So(app.Environment["string"], ShouldEqual, "string")
+		So(app.Environment["int"], ShouldEqual, 1)
+	})
 }
 
 func TestAppSpace(t *testing.T) {

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -233,6 +233,14 @@ const appPayload = `{
    }
 }`
 
+const appPayloadWithEnvironment_json = `{
+   "metadata": {
+   },
+   "entity": {
+      "environment_json": {"string": "string", "int": 1}
+   }
+}`
+
 const spacePayload = `{
    "metadata": {
       "guid": "a72fa1e8-c694-47b3-85f2-55f61fd00d73",


### PR DESCRIPTION
When environment_json contains values of different types.

```
{
    ....
    "entity": {
         ....
         "environment_json": {"string": "string", "int": 1}
    }
```
}

We get a err,
```
2015/05/06 11:24:32 Error unmarshaling app json: cannot unmarshal number into Go value of type string
```
As we make the assumtption in the App struct that values are always strings
```
type App struct {
	Guid        string            `json:"guid"`
	Name        string            `json:"name"`
	Environment map[string]string `json:"environment_json"`
	SpaceURL    string            `json:"space_url"`
	SpaceData   SpaceResource     `json:"space"`
	c           *Client
}
```

This PR fixes this.