### PR TITLE
Follow next_url in ListApps

### DIFF
--- a/apps_test.go
+++ b/apps_test.go
@@ -8,7 +8,11 @@ import (
 
 func TestListApps(t *testing.T) {
 	Convey("List Apps", t, func() {
-		setup("GET", "/v2/apps", listAppsPayload)
+		mocks := []MockRoute{
+			{"GET", "/v2/apps", listAppsPayload},
+			{"GET", "/v2/appsPage2", listAppsPayloadPage2},
+		}
+		setupMultiple(mocks)
 		defer teardown()
 		c := &Config{
 			ApiAddress:   server.URL,
@@ -17,10 +21,12 @@ func TestListApps(t *testing.T) {
 		}
 		client := NewClient(c)
 		apps := client.ListApps()
-		So(len(apps), ShouldEqual, 1)
+		So(len(apps), ShouldEqual, 2)
 		So(apps[0].Guid, ShouldEqual, "af15c29a-6bde-4a9b-8cdf-43aa0d4b7e3c")
 		So(apps[0].Name, ShouldEqual, "app-test")
 		So(apps[0].Environment["FOOBAR"], ShouldEqual, "QUX")
+		So(apps[1].Guid, ShouldEqual, "f9ad202b-76dd-44ec-b7c2-fd2417a561e8")
+		So(apps[1].Name, ShouldEqual, "app-test2")
 	})
 }
 

--- a/apps_test.go
+++ b/apps_test.go
@@ -26,7 +26,7 @@ func TestListApps(t *testing.T) {
 
 func TestAppByGuid(t *testing.T) {
 	Convey("App By GUID", t, func() {
-		setup("GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2", appPayload)
+		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2", appPayload})
 		defer teardown()
 		c := &Config{
 			ApiAddress:   server.URL,
@@ -56,7 +56,7 @@ func TestAppByGuid(t *testing.T) {
 
 func TestAppSpace(t *testing.T) {
 	Convey("Find app space", t, func() {
-		setup("GET", "/v2/spaces/foobar", spacePayload)
+		setup(MockRoute{"GET", "/v2/spaces/foobar", spacePayload})
 		defer teardown()
 		c := &Config{
 			ApiAddress:   server.URL,

--- a/apps_test.go
+++ b/apps_test.go
@@ -46,7 +46,7 @@ func TestAppByGuid(t *testing.T) {
 	})
 
 	Convey("App By GUID with environment variables with different types", t, func() {
-		setup("GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2", appPayloadWithEnvironment_json)
+		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2", appPayloadWithEnvironment_json})
 		defer teardown()
 		c := &Config{
 			ApiAddress:   server.URL,

--- a/cf_test.go
+++ b/cf_test.go
@@ -1,10 +1,9 @@
 package cfclient
 
 import (
+	"github.com/go-martini/martini"
 	"net/http"
 	"net/http/httptest"
-
-	"github.com/go-martini/martini"
 )
 
 var (
@@ -12,19 +11,34 @@ var (
 	server *httptest.Server
 )
 
-func setup(method, endpoint, output string) {
+type MockRoute struct {
+	Method   string
+	Endpoint string
+	Output   string
+}
+
+func setup(mock MockRoute) {
+	setupMultiple([]MockRoute{mock})
+}
+
+func setupMultiple(mockEndpoints []MockRoute) {
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
 	m := martini.New()
 	r := martini.NewRouter()
-	if method == "GET" {
-		r.Get(endpoint, func() string {
-			return output
-		})
-	} else if method == "POST" {
-		r.Post(endpoint, func() string {
-			return output
-		})
+	for _, mock := range mockEndpoints {
+		method := mock.Method
+		endpoint := mock.Endpoint
+		output := mock.Output
+		if method == "GET" {
+			r.Get(endpoint, func() string {
+				return output
+			})
+		} else if method == "POST" {
+			r.Post(endpoint, func() string {
+				return output
+			})
+		}
 	}
 	m.Action(r.Handle)
 	mux.Handle("/", m)

--- a/orgs_test.go
+++ b/orgs_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestListOrgs(t *testing.T) {
 	Convey("List Org", t, func() {
-		setup("GET", "/v2/organizations", listOrgsPayload)
+		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload})
 		defer teardown()
 		c := &Config{
 			ApiAddress:   server.URL,
@@ -25,7 +25,7 @@ func TestListOrgs(t *testing.T) {
 
 func TestOrgSpaces(t *testing.T) {
 	Convey("Get spaces by org", t, func() {
-		setup("GET", "/v2/organizations/foo/spaces", orgSpacesPayload)
+		setup(MockRoute{"GET", "/v2/organizations/foo/spaces", orgSpacesPayload})
 		defer teardown()
 		c := &Config{
 			ApiAddress:   server.URL,

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -151,7 +151,7 @@ const listAppsPayload = `{
    "total_results": 28,
    "total_pages": 1,
    "prev_url": null,
-   "next_url": null,
+   "next_url": "/v2/appsPage2",
    "resources": [
       {
          "metadata": {
@@ -162,6 +162,54 @@ const listAppsPayload = `{
          },
          "entity": {
             "name": "app-test",
+            "production": false,
+            "space_guid": "8efd7c5c-d83c-4786-b399-b7bd548839e1",
+            "stack_guid": "2c531037-68a2-4e2c-a9e0-71f9d0abf0d4",
+            "buildpack": "https://github.com/cloudfoundry/buildpack-go.git",
+            "detected_buildpack": null,
+            "environment_json": {
+               "FOOBAR": "QUX"
+            },
+            "memory": 256,
+            "instances": 1,
+            "disk_quota": 1024,
+            "state": "STARTED",
+            "version": "97ef1272-9eb6-4839-9df1-5ed4f55b5c45",
+            "command": null,
+            "console": false,
+            "debug": null,
+            "staging_task_id": "5879c8d06a10491a879734162000def8",
+            "package_state": "PENDING",
+            "health_check_timeout": null,
+            "staging_failed_reason": null,
+            "docker_image": null,
+            "package_updated_at": "2014-11-10T14:08:50+00:00",
+            "detected_start_command": "app-launching-service-broker",
+            "space_url": "/v2/spaces/8efd7c5c-d83c-4786-b399-b7bd548839e1",
+            "stack_url": "/v2/stacks/2c531037-68a2-4e2c-a9e0-71f9d0abf0d4",
+            "events_url": "/v2/apps/af15c29a-6bde-4a9b-8cdf-43aa0d4b7e3c/events",
+            "service_bindings_url": "/v2/apps/af15c29a-6bde-4a9b-8cdf-43aa0d4b7e3c/service_bindings",
+            "routes_url": "/v2/apps/af15c29a-6bde-4a9b-8cdf-43aa0d4b7e3c/routes"
+         }
+      }
+   ]
+}`
+
+const listAppsPayloadPage2 = `{
+   "total_results": 28,
+   "total_pages": 1,
+   "prev_url": null,
+   "next_url": null,
+   "resources": [
+      {
+         "metadata": {
+            "guid": "f9ad202b-76dd-44ec-b7c2-fd2417a561e8",
+            "url": "/v2/apps/f9ad202b-76dd-44ec-b7c2-fd2417a561e8",
+            "created_at": "2014-10-10T21:03:13+00:00",
+            "updated_at": "2014-11-10T14:07:31+00:00"
+         },
+         "entity": {
+            "name": "app-test2",
             "production": false,
             "space_guid": "8efd7c5c-d83c-4786-b399-b7bd548839e1",
             "stack_guid": "2c531037-68a2-4e2c-a9e0-71f9d0abf0d4",

--- a/services_test.go
+++ b/services_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestListServices(t *testing.T) {
 	Convey("List Services", t, func() {
-		setup("GET", "/v2/services", listServicePayload)
+		setup(MockRoute{"GET", "/v2/services", listServicePayload})
 		defer teardown()
 		c := &Config{
 			ApiAddress:   server.URL,

--- a/spaces_test.go
+++ b/spaces_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestListSpaces(t *testing.T) {
 	Convey("List Space", t, func() {
-		setup("GET", "/v2/spaces", listSpacesPayload)
+		setup(MockRoute{"GET", "/v2/spaces", listSpacesPayload})
 		defer teardown()
 		c := &Config{
 			ApiAddress:   server.URL,
@@ -25,7 +25,7 @@ func TestListSpaces(t *testing.T) {
 
 func TestSpaceOrg(t *testing.T) {
 	Convey("Find space org", t, func() {
-		setup("GET", "/v2/org/foobar", orgPayload)
+		setup(MockRoute{"GET", "/v2/org/foobar", orgPayload})
 		defer teardown()
 		c := &Config{
 			ApiAddress:   server.URL,


### PR DESCRIPTION
We need to follow next_url if present when geting all apps.

```
cf curl "/v2/apps" | head -n 5
{
  "total_results": 346,
  "total_pages": 7,
  "prev_url": null,
  "next_url": "/v2/apps?order-direction=asc&page=2&results-per-page=50",
```
