### PR TITLE
Delete duplicate fetching of getToken in doRequest.

### DIFF
--- a/client.go
+++ b/client.go
@@ -114,8 +114,6 @@ func (c *Client) doRequest(r *request) (*http.Response, error) {
 		return nil, err
 	}
 
-	c.GetToken()
-
 	req.Header.Set("Authorization", c.GetToken())
 	req.Header.Set("accept", "application/json")
 	req.Header.Set("content-type", "application/json")


### PR DESCRIPTION
Remove unnecessary fetching of token that goes into the ether.