### PR TITLE
Add support for getting and deleting application instance information

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -2,6 +2,7 @@ package cfclient
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 )
@@ -25,6 +26,10 @@ type App struct {
 	SpaceURL    string                 `json:"space_url"`
 	SpaceData   SpaceResource          `json:"space"`
 	c           *Client
+}
+
+type AppInstance struct {
+	State string `json:"state"`
 }
 
 func (a *App) Space() Space {
@@ -84,6 +89,26 @@ func (c *Client) ListApps() []App {
 		}
 	}
 	return apps
+}
+
+func (c *Client) GetAppInstances(guid string) map[string]AppInstance {
+	var appInstances map[string]AppInstance
+
+	requestURL := fmt.Sprintf("/v2/apps/%s/instances", guid)
+	r := c.newRequest("GET", requestURL)
+	resp, err := c.doRequest(r)
+	if err != nil {
+		log.Printf("Error requesting app instances %v", err)
+	}
+	resBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("Error reading app instances %v", err)
+	}
+	err = json.Unmarshal(resBody, &appInstances)
+	if err != nil {
+		log.Printf("Error unmarshalling app instances %v", err)
+	}
+	return appInstances
 }
 
 func (c *Client) AppByGuid(guid string) App {

--- a/apps.go
+++ b/apps.go
@@ -111,6 +111,20 @@ func (c *Client) GetAppInstances(guid string) map[string]AppInstance {
 	return appInstances
 }
 
+func (c *Client) KillAppInstance(guid string, index string) error {
+	requestURL := fmt.Sprintf("/v2/apps/%s/instances/%s", guid, index)
+	r := c.newRequest("DELETE", requestURL)
+	resp, err := c.doRequest(r)
+	if err != nil {
+		log.Printf("Error killing app instance %v", err)
+		return fmt.Errorf("Error stopping app %s at index %s", guid, index)
+	}
+	if resp.StatusCode != 204 {
+		return fmt.Errorf("Error stopping app %s at index %s", guid, index)
+	}
+	return nil
+}
+
 func (c *Client) AppByGuid(guid string) App {
 	var appResource AppResource
 	r := c.newRequest("GET", "/v2/apps/"+guid+"?inline-relations-depth=2")

--- a/apps_test.go
+++ b/apps_test.go
@@ -60,6 +60,36 @@ func TestAppByGuid(t *testing.T) {
 	})
 }
 
+func TestGetAppInstances(t *testing.T) {
+	Convey("App completely running", t, func() {
+		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/instances", appInstancePayload})
+		defer teardown()
+		c := &Config{
+			ApiAddress:   server.URL,
+			LoginAddress: fakeUAAServer.URL,
+			Token:        "foobar",
+		}
+		client := NewClient(c)
+		appInstances := client.GetAppInstances("9902530c-c634-4864-a189-71d763cb12e2")
+		So(appInstances["0"].State, ShouldEqual, "RUNNING")
+		So(appInstances["1"].State, ShouldEqual, "RUNNING")
+	})
+
+	Convey("App partially running", t, func() {
+		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/instances", appInstanceUnhealthyPayload})
+		defer teardown()
+		c := &Config{
+			ApiAddress:   server.URL,
+			LoginAddress: fakeUAAServer.URL,
+			Token:        "foobar",
+		}
+		client := NewClient(c)
+		appInstances := client.GetAppInstances("9902530c-c634-4864-a189-71d763cb12e2")
+		So(appInstances["0"].State, ShouldEqual, "RUNNING")
+		So(appInstances["1"].State, ShouldEqual, "STARTING")
+	})
+}
+
 func TestAppSpace(t *testing.T) {
 	Convey("Find app space", t, func() {
 		setup(MockRoute{"GET", "/v2/spaces/foobar", spacePayload})

--- a/apps_test.go
+++ b/apps_test.go
@@ -90,6 +90,20 @@ func TestGetAppInstances(t *testing.T) {
 	})
 }
 
+func TestKillAppInstance(t *testing.T) {
+	Convey("Kills an app instance", t, func() {
+		setup(MockRoute{"DELETE", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/instances/0", ""})
+		defer teardown()
+		c := &Config{
+			ApiAddress:   server.URL,
+			LoginAddress: fakeUAAServer.URL,
+			Token:        "foobar",
+		}
+		client := NewClient(c)
+		So(client.KillAppInstance("9902530c-c634-4864-a189-71d763cb12e2", "0"), ShouldBeNil)
+	})
+}
+
 func TestAppSpace(t *testing.T) {
 	Convey("Find app space", t, func() {
 		setup(MockRoute{"GET", "/v2/spaces/foobar", spacePayload})

--- a/cf_test.go
+++ b/cf_test.go
@@ -43,6 +43,10 @@ func setupMultiple(mockEndpoints []MockRoute) {
 			r.Post(endpoint, func() string {
 				return output
 			})
+		} else if method == "DELETE" {
+			r.Delete(endpoint, func() (int, string) {
+				return 204, output
+			})
 		}
 	}
 	r.Get("/v2/info", func(r render.Render) {

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -289,6 +289,44 @@ const appPayloadWithEnvironment_json = `{
    }
 }`
 
+const appInstancePayload = `{
+   "0": {
+      "state": "RUNNING",
+      "since": 1455210430.5104606,
+      "debug_ip": null,
+      "debug_port": null,
+      "console_ip": null,
+      "console_port": null
+   },
+   "1": {
+      "state": "RUNNING",
+      "since": 1455210430.3912115,
+      "debug_ip": null,
+      "debug_port": null,
+      "console_ip": null,
+      "console_port": null
+   }
+}`
+
+const appInstanceUnhealthyPayload = `{
+   "0": {
+      "state": "RUNNING",
+      "since": 1455210430.5104606,
+      "debug_ip": null,
+      "debug_port": null,
+      "console_ip": null,
+      "console_port": null
+   },
+   "1": {
+      "state": "STARTING",
+      "since": 1455210430.3912115,
+      "debug_ip": null,
+      "debug_port": null,
+      "console_ip": null,
+      "console_port": null
+   }
+}`
+
 const spacePayload = `{
    "metadata": {
       "guid": "a72fa1e8-c694-47b3-85f2-55f61fd00d73",


### PR DESCRIPTION
I am currently working from a forked version of the go-cfclient as it was the quickest way to get the new features that I require. These features may be useful to others as well, being part of original repo seems most appropriate.