### PR TITLE
Get ListSpaces to follow NextPage and Improve ListAllSecGroups

### DIFF
--- a/payloads_test.go
+++ b/payloads_test.go
@@ -90,6 +90,14 @@ const orgSpacesPayload = `{
    ]
 }`
 
+const emptyResources = `{
+   "total_results": 0,
+   "total_pages": 1,
+   "prev_url": null,
+   "next_url": null,
+   "resources": []
+}`
+
 const listSpacesPayload = `{
    "total_results": 8,
    "total_pages": 2,

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -92,9 +92,9 @@ const orgSpacesPayload = `{
 
 const listSpacesPayload = `{
    "total_results": 8,
-   "total_pages": 1,
+   "total_pages": 2,
    "prev_url": null,
-   "next_url": null,
+   "next_url": "/v2/spacesPage2",
    "resources": [
       {
          "metadata": {
@@ -142,6 +142,63 @@ const listSpacesPayload = `{
             "app_events_url": "/v2/spaces/657b5923-7de0-486a-9928-b4d78ee24931/app_events",
             "events_url": "/v2/spaces/657b5923-7de0-486a-9928-b4d78ee24931/events",
             "security_groups_url": "/v2/spaces/657b5923-7de0-486a-9928-b4d78ee24931/security_groups"
+         }
+      }
+   ]
+}`
+
+const listSpacesPayloadPage2 = `{
+   "total_results": 8,
+   "total_pages": 2,
+   "prev_url": null,
+   "next_url": null,
+   "resources": [
+      {
+         "metadata": {
+            "guid": "9ffd7c5c-d83c-4786-b399-b7bd54883977",
+            "url": "/v2/spaces/9ffd7c5c-d83c-4786-b399-b7bd54883977",
+            "created_at": "2014-09-24T13:54:54+00:00",
+            "updated_at": null
+         },
+         "entity": {
+            "name": "test",
+            "organization_guid": "a537761f-9d93-4b30-af17-3d73dbca181b",
+            "space_quota_definition_guid": null,
+            "organization_url": "/v2/organizations/b737761f-9d93-4b30-af17-3d73dbca18aa",
+            "developers_url": "/v2/spaces/9ffd7c5c-d83c-4786-b399-b7bd54883977/developers",
+            "managers_url": "/v2/spaces/9ffd7c5c-d83c-4786-b399-b7bd54883977/managers",
+            "auditors_url": "/v2/spaces/9ffd7c5c-d83c-4786-b399-b7bd54883977/auditors",
+            "apps_url": "/v2/spaces/9ffd7c5c-d83c-4786-b399-b7bd54883977/apps",
+            "routes_url": "/v2/spaces/9ffd7c5c-d83c-4786-b399-b7bd54883977/routes",
+            "domains_url": "/v2/spaces/9ffd7c5c-d83c-4786-b399-b7bd54883977/domains",
+            "service_instances_url": "/v2/spaces/9ffd7c5c-d83c-4786-b399-b7bd54883977/service_inst2ances",
+            "app_events_url": "/v2/spaces/9ffd7c5c-d83c-4786-b399-b7bd54883977/app_events",
+            "events_url": "/v2/spaces/9ffd7c5c-d83c-4786-b399-b7bd54883977/events",
+            "security_groups_url": "/v2/spaces/8efd7c5c-d83c-4786-b399-b7bd548839e1/security_groups"
+         }
+      },
+      {
+         "metadata": {
+            "guid": "329b5923-7de0-486a-9928-b4d78ee24982",
+            "url": "/v2/spaces/329b5923-7de0-486a-9928-b4d78ee24982",
+            "created_at": "2014-09-26T13:37:31+00:00",
+            "updated_at": null
+         },
+         "entity": {
+            "name": "prod",
+            "organization_guid": "da0dba14-6064-4f7a-b15a-ff9e677e49b2",
+            "space_quota_definition_guid": null,
+            "organization_url": "/v2/organizations/ad0dba14-6064-4f7a-b15a-ff9e677e492b",
+            "developers_url": "/v2/spaces/329b5923-7de0-486a-9928-b4d78ee24982/developers",
+            "managers_url": "/v2/spaces/329b5923-7de0-486a-9928-b4d78ee24982/managers",
+            "auditors_url": "/v2/spaces/329b5923-7de0-486a-9928-b4d78ee24982/auditors",
+            "apps_url": "/v2/spaces/329b5923-7de0-486a-9928-b4d78ee24982/apps",
+            "routes_url": "/v2/spaces/329b5923-7de0-486a-9928-b4d78ee24982/routes",
+            "domains_url": "/v2/spaces/329b5923-7de0-486a-9928-b4d78ee24982/domains",
+            "service_instances_url": "/v2/spaces/329b5923-7de0-486a-9928-b4d78ee24982/service_instances",
+            "app_events_url": "/v2/spaces/329b5923-7de0-486a-9928-b4d78ee24982/app_events",
+            "events_url": "/v2/spaces/329b5923-7de0-486a-9928-b4d78ee24982/events",
+            "security_groups_url": "/v2/spaces/329b5923-7de0-486a-9928-b4d78ee24982/security_groups"
          }
       }
    ]

--- a/secgroups_test.go
+++ b/secgroups_test.go
@@ -11,6 +11,7 @@ func TestListSecGroups(t *testing.T) {
 		mocks := []MockRoute{
 			{"GET", "/v2/security_groups", listSecGroupsPayload},
 			{"GET", "/v2/security_groupsPage2", listSecGroupsPayloadPage2},
+			{"GET", "/v2/security_groups/af15c29a-6bde-4a9b-8cdf-43aa0d4b7e3c/spaces", emptyResources},
 		}
 		setupMultiple(mocks)
 		defer teardown()
@@ -50,5 +51,38 @@ func TestListSecGroups(t *testing.T) {
 		So(SecGroups[1].SpacesData[1].Entity.Name, ShouldEqual, "space-test2")
 		So(SecGroups[1].SpacesData[2].Entity.Guid, ShouldEqual, "c7a0d1bf-ad74-4b3c-8f4a-0c33859adsa1")
 		So(SecGroups[1].SpacesData[2].Entity.Name, ShouldEqual, "space-test3")
+	})
+}
+
+func TestSecGroupListSpaceResources(t *testing.T) {
+	Convey("List Space Resources", t, func() {
+		mocks := []MockRoute{
+			{"GET", "/v2/security_groups/123/spaces", listSpacesPayload},
+			{"GET", "/v2/spacesPage2", listSpacesPayloadPage2},
+		}
+		setupMultiple(mocks)
+		defer teardown()
+		c := &Config{
+			ApiAddress:   server.URL,
+			LoginAddress: fakeUAAServer.URL,
+			Token:        "foobar",
+		}
+		client := NewClient(c)
+		secGroup := &SecGroup{
+			Guid:      "123",
+			Name:      "test-sec-group",
+			SpacesURL: "/v2/security_groups/123/spaces",
+			c:         client,
+		}
+		spaces := secGroup.ListSpaceResources()
+		So(len(spaces), ShouldEqual, 4)
+		So(spaces[0].Entity.Guid, ShouldEqual, "8efd7c5c-d83c-4786-b399-b7bd548839e1")
+		So(spaces[0].Entity.Name, ShouldEqual, "dev")
+		So(spaces[1].Entity.Guid, ShouldEqual, "657b5923-7de0-486a-9928-b4d78ee24931")
+		So(spaces[1].Entity.Name, ShouldEqual, "demo")
+		So(spaces[2].Entity.Guid, ShouldEqual, "9ffd7c5c-d83c-4786-b399-b7bd54883977")
+		So(spaces[2].Entity.Name, ShouldEqual, "test")
+		So(spaces[3].Entity.Guid, ShouldEqual, "329b5923-7de0-486a-9928-b4d78ee24982")
+		So(spaces[3].Entity.Name, ShouldEqual, "prod")
 	})
 }

--- a/spaces.go
+++ b/spaces.go
@@ -9,6 +9,7 @@ import (
 type SpaceResponse struct {
 	Count     int             `json:"total_results"`
 	Pages     int             `json:"total_pages"`
+	NextUrl   string          `json:"next_url"`
 	Resources []SpaceResource `json:"resources"`
 }
 
@@ -48,25 +49,35 @@ func (s *Space) Org() Org {
 
 func (c *Client) ListSpaces() []Space {
 	var spaces []Space
-	var spaceResp SpaceResponse
-	r := c.newRequest("GET", "/v2/spaces")
-	resp, err := c.doRequest(r)
-	if err != nil {
-		log.Printf("Error requesting spaces %v", err)
-	}
-	resBody, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		log.Printf("Error reading space request %v", resBody)
-	}
 
-	err = json.Unmarshal(resBody, &spaceResp)
-	if err != nil {
-		log.Printf("Error unmarshalling space %v", err)
-	}
-	for _, space := range spaceResp.Resources {
-		space.Entity.Guid = space.Meta.Guid
-		space.Entity.c = c
-		spaces = append(spaces, space.Entity)
+	requestUrl := "/v2/spaces"
+
+	for {
+		var spaceResp SpaceResponse
+		r := c.newRequest("GET", requestUrl)
+		resp, err := c.doRequest(r)
+		if err != nil {
+			log.Printf("Error requesting spaces %v", err)
+		}
+		resBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Printf("Error reading space request %v", resBody)
+		}
+
+		err = json.Unmarshal(resBody, &spaceResp)
+		if err != nil {
+			log.Printf("Error unmarshalling space %v", err)
+		}
+		for _, space := range spaceResp.Resources {
+			space.Entity.Guid = space.Meta.Guid
+			space.Entity.c = c
+			spaces = append(spaces, space.Entity)
+		}
+		requestUrl = spaceResp.NextUrl
+		if requestUrl == "" {
+			break
+		}
+		resp.Body.Close()
 	}
 	return spaces
 }

--- a/spaces.go
+++ b/spaces.go
@@ -49,25 +49,9 @@ func (s *Space) Org() Org {
 
 func (c *Client) ListSpaces() []Space {
 	var spaces []Space
-
 	requestUrl := "/v2/spaces"
-
 	for {
-		var spaceResp SpaceResponse
-		r := c.newRequest("GET", requestUrl)
-		resp, err := c.doRequest(r)
-		if err != nil {
-			log.Printf("Error requesting spaces %v", err)
-		}
-		resBody, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			log.Printf("Error reading space request %v", resBody)
-		}
-
-		err = json.Unmarshal(resBody, &spaceResp)
-		if err != nil {
-			log.Printf("Error unmarshalling space %v", err)
-		}
+		var spaceResp = c.getSpaceResponse(requestUrl)
 		for _, space := range spaceResp.Resources {
 			space.Entity.Guid = space.Meta.Guid
 			space.Entity.c = c
@@ -77,7 +61,25 @@ func (c *Client) ListSpaces() []Space {
 		if requestUrl == "" {
 			break
 		}
-		resp.Body.Close()
 	}
 	return spaces
+}
+
+func (c *Client) getSpaceResponse(requestUrl string) SpaceResponse {
+	var spaceResp SpaceResponse
+	r := c.newRequest("GET", requestUrl)
+	resp, err := c.doRequest(r)
+	if err != nil {
+		log.Printf("Error requesting spaces %v", err)
+	}
+	resBody, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		log.Printf("Error reading space request %v", resBody)
+	}
+	err = json.Unmarshal(resBody, &spaceResp)
+	if err != nil {
+		log.Printf("Error unmarshalling space %v", err)
+	}
+	return spaceResp
 }

--- a/spaces_test.go
+++ b/spaces_test.go
@@ -8,7 +8,11 @@ import (
 
 func TestListSpaces(t *testing.T) {
 	Convey("List Space", t, func() {
-		setup(MockRoute{"GET", "/v2/spaces", listSpacesPayload})
+		mocks := []MockRoute{
+			{"GET", "/v2/spaces", listSpacesPayload},
+			{"GET", "/v2/spacesPage2", listSpacesPayloadPage2},
+		}
+		setupMultiple(mocks)
 		defer teardown()
 		c := &Config{
 			ApiAddress:   server.URL,
@@ -17,9 +21,15 @@ func TestListSpaces(t *testing.T) {
 		}
 		client := NewClient(c)
 		spaces := client.ListSpaces()
-		So(len(spaces), ShouldEqual, 2)
+		So(len(spaces), ShouldEqual, 4)
 		So(spaces[0].Guid, ShouldEqual, "8efd7c5c-d83c-4786-b399-b7bd548839e1")
 		So(spaces[0].Name, ShouldEqual, "dev")
+		So(spaces[1].Guid, ShouldEqual, "657b5923-7de0-486a-9928-b4d78ee24931")
+		So(spaces[1].Name, ShouldEqual, "demo")
+		So(spaces[2].Guid, ShouldEqual, "9ffd7c5c-d83c-4786-b399-b7bd54883977")
+		So(spaces[2].Name, ShouldEqual, "test")
+		So(spaces[3].Guid, ShouldEqual, "329b5923-7de0-486a-9928-b4d78ee24982")
+		So(spaces[3].Name, ShouldEqual, "prod")
 	})
 }
 


### PR DESCRIPTION
I noticed during some manual testing that inline-relations-depth fails to return anything if the response is too large. For example if a security group is bound to ~50 spaces no SpacesData was being populated. I have added a manual check to retrieve spaces data if none was returned dynamically.

As this check largely re-used parts of the ListSpaces function I split it out and re-used what I could.