### PR TITLE
Enable to set arbitrary body of request

### DIFF
--- a/client.go
+++ b/client.go
@@ -162,6 +162,17 @@ func (c *Client) NewRequest(method, path string) *request {
 	return r
 }
 
+// NewRequestWithBody is used to create a new request with
+// arbigtrary body io.Reader.
+func (c *Client) NewRequestWithBody(method, path string, body io.Reader) *request {
+	r := c.NewRequest(method, path)
+
+	// Set request body
+	r.body = body
+
+	return r
+}
+
 // DoRequest runs a request with our client
 func (c *Client) DoRequest(r *request) (*http.Response, error) {
 	req, err := r.toHTTP()


### PR DESCRIPTION
Sometimes we want to create a request that `go-cfclient` doesn't support, yet. If we can set body (`io.Reader`), we can do that. This PR adds new function `NewRequestWithBody` that allows construct `*request` with arbitrary body. 

For example, with this function, we can easily create a new request to create organization.

```golang
 req := c.client.NewRequestWithBody("POST", "/v2/organizations", bytes.NewReader(body))
 res, err := c.client.DoRequest(req)
... 
```