### PR TITLE
Able to setup User Agent

### DIFF
--- a/appevents_test.go
+++ b/appevents_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestListAppEvents(t *testing.T) {
 	Convey("List App Events", t, func() {
-		setup(MockRoute{"GET", "/v2/events", listAppsCreatedEventPayload})
+		setup(MockRoute{"GET", "/v2/events", listAppsCreatedEventPayload, ""}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -29,7 +29,7 @@ func TestListAppEvents(t *testing.T) {
 
 func TestListAppEventsByQuery(t *testing.T) {
 	Convey("List App Events By Query", t, func() {
-		setup(MockRoute{"GET", "/v2/events", listAppsCreatedEventPayload})
+		setup(MockRoute{"GET", "/v2/events", listAppsCreatedEventPayload, ""}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,

--- a/apps_test.go
+++ b/apps_test.go
@@ -9,14 +9,15 @@ import (
 func TestListApps(t *testing.T) {
 	Convey("List Apps", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/apps", listAppsPayload},
-			{"GET", "/v2/appsPage2", listAppsPayloadPage2},
+			{"GET", "/v2/apps", listAppsPayload, "Test-golang"},
+			{"GET", "/v2/appsPage2", listAppsPayloadPage2, "Test-golang"},
 		}
-		setupMultiple(mocks)
+		setupMultiple(mocks, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
 			Token:      "foobar",
+			UserAgent:  "Test-golang",
 		}
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
@@ -35,7 +36,7 @@ func TestListApps(t *testing.T) {
 
 func TestAppByGuid(t *testing.T) {
 	Convey("App By GUID", t, func() {
-		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2", appPayload})
+		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2", appPayload, ""}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -52,7 +53,7 @@ func TestAppByGuid(t *testing.T) {
 	})
 
 	Convey("App By GUID with environment variables with different types", t, func() {
-		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2", appPayloadWithEnvironment_json})
+		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2", appPayloadWithEnvironment_json, ""}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -71,7 +72,7 @@ func TestAppByGuid(t *testing.T) {
 
 func TestGetAppInstances(t *testing.T) {
 	Convey("App completely running", t, func() {
-		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/instances", appInstancePayload})
+		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/instances", appInstancePayload, ""}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -88,7 +89,7 @@ func TestGetAppInstances(t *testing.T) {
 	})
 
 	Convey("App partially running", t, func() {
-		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/instances", appInstanceUnhealthyPayload})
+		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/instances", appInstanceUnhealthyPayload, ""}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -107,7 +108,7 @@ func TestGetAppInstances(t *testing.T) {
 
 func TestKillAppInstance(t *testing.T) {
 	Convey("Kills an app instance", t, func() {
-		setup(MockRoute{"DELETE", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/instances/0", ""})
+		setup(MockRoute{"DELETE", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/instances/0", "", ""}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -122,7 +123,7 @@ func TestKillAppInstance(t *testing.T) {
 
 func TestAppSpace(t *testing.T) {
 	Convey("Find app space", t, func() {
-		setup(MockRoute{"GET", "/v2/spaces/foobar", spacePayload})
+		setup(MockRoute{"GET", "/v2/spaces/foobar", spacePayload, ""}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,

--- a/client.go
+++ b/client.go
@@ -38,6 +38,7 @@ type Config struct {
 	HttpClient        *http.Client
 	Token             string `json:"auth_token"`
 	TokenSource       oauth2.TokenSource
+	UserAgent         string `json:"user_agent"`
 }
 
 // request is used to help build up a request
@@ -60,6 +61,7 @@ func DefaultConfig() *Config {
 		Token:             "",
 		SkipSslValidation: false,
 		HttpClient:        http.DefaultClient,
+		UserAgent:         "Go-CF-client/1.1",
 	}
 }
 
@@ -93,6 +95,9 @@ func NewClient(config *Config) (client *Client, err error) {
 		config.Token = defConfig.Token
 	}
 
+	if len(config.UserAgent) == 0 {
+		config.UserAgent = defConfig.UserAgent
+	}
 	ctx := context.Background()
 	if config.SkipSslValidation == false {
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, defConfig.HttpClient)
@@ -208,6 +213,7 @@ func (c *Client) DoRequest(r *request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("User-Agent", c.config.UserAgent)
 	resp, err := c.config.HttpClient.Do(req)
 	return resp, err
 }

--- a/client_test.go
+++ b/client_test.go
@@ -15,12 +15,13 @@ func TestDefaultConfig(t *testing.T) {
 		So(c.Password, ShouldEqual, "admin")
 		So(c.SkipSslValidation, ShouldEqual, false)
 		So(c.Token, ShouldEqual, "")
+		So(c.UserAgent, ShouldEqual, "Go-CF-client/1.1")
 	})
 }
 
 func TestMakeRequest(t *testing.T) {
-	Convey("Test making request", t, func() {
-		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload})
+	Convey("Test making request b", t, func() {
+		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, ""}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress:        server.URL,
@@ -40,7 +41,7 @@ func TestMakeRequest(t *testing.T) {
 func TestTokenRefresh(t *testing.T) {
 	gomega.RegisterTestingT(t)
 	Convey("Test making request", t, func() {
-		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload})
+		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, ""}, t)
 		c := &Config{
 			ApiAddress: server.URL,
 			Username:   "foo",

--- a/orgs.go
+++ b/orgs.go
@@ -30,7 +30,6 @@ func (c *Client) ListOrgs() ([]Org, error) {
 	requestUrl := "/v2/organizations"
 	for {
 		orgResp, err := c.getOrgResponse(requestUrl)
-		fmt.Println(orgResp)
 		if err != nil {
 			return []Org{}, err
 		}
@@ -40,7 +39,6 @@ func (c *Client) ListOrgs() ([]Org, error) {
 			orgs = append(orgs, org.Entity)
 		}
 		requestUrl = orgResp.NextUrl
-		fmt.Println(requestUrl)
 		if requestUrl == "" {
 			break
 		}

--- a/orgs_test.go
+++ b/orgs_test.go
@@ -9,10 +9,10 @@ import (
 func TestListOrgs(t *testing.T) {
 	Convey("List Org", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/organizations", listOrgsPayload},
-			{"GET", "/v2/orgsPage2", listOrgsPayloadPage2},
+			{"GET", "/v2/organizations", listOrgsPayload, ""},
+			{"GET", "/v2/orgsPage2", listOrgsPayloadPage2, ""},
 		}
-		setupMultiple(mocks)
+		setupMultiple(mocks, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -32,7 +32,7 @@ func TestListOrgs(t *testing.T) {
 
 func TestOrgSpaces(t *testing.T) {
 	Convey("Get spaces by org", t, func() {
-		setup(MockRoute{"GET", "/v2/organizations/foo/spaces", orgSpacesPayload})
+		setup(MockRoute{"GET", "/v2/organizations/foo/spaces", orgSpacesPayload, ""}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,

--- a/secgroups_test.go
+++ b/secgroups_test.go
@@ -9,11 +9,11 @@ import (
 func TestListSecGroups(t *testing.T) {
 	Convey("List SecGroups", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/security_groups", listSecGroupsPayload},
-			{"GET", "/v2/security_groupsPage2", listSecGroupsPayloadPage2},
-			{"GET", "/v2/security_groups/af15c29a-6bde-4a9b-8cdf-43aa0d4b7e3c/spaces", emptyResources},
+			{"GET", "/v2/security_groups", listSecGroupsPayload, ""},
+			{"GET", "/v2/security_groupsPage2", listSecGroupsPayloadPage2, ""},
+			{"GET", "/v2/security_groups/af15c29a-6bde-4a9b-8cdf-43aa0d4b7e3c/spaces", emptyResources, ""},
 		}
-		setupMultiple(mocks)
+		setupMultiple(mocks, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -60,10 +60,10 @@ func TestListSecGroups(t *testing.T) {
 func TestSecGroupListSpaceResources(t *testing.T) {
 	Convey("List Space Resources", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/security_groups/123/spaces", listSpacesPayload},
-			{"GET", "/v2/spacesPage2", listSpacesPayloadPage2},
+			{"GET", "/v2/security_groups/123/spaces", listSpacesPayload, ""},
+			{"GET", "/v2/spacesPage2", listSpacesPayloadPage2, ""},
 		}
-		setupMultiple(mocks)
+		setupMultiple(mocks, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,

--- a/service_instances_test.go
+++ b/service_instances_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestServiceInstanceByGuid(t *testing.T) {
 	Convey("Service instance by Guid", t, func() {
-		setup(MockRoute{"GET", "/v2/service_instances/8423ca96-90ad-411f-b77a-0907844949fc", serviceInstancePayload})
+		setup(MockRoute{"GET", "/v2/service_instances/8423ca96-90ad-411f-b77a-0907844949fc", serviceInstancePayload, ""}, t)
 		defer teardown()
 
 		c := &Config{

--- a/services_test.go
+++ b/services_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestListServices(t *testing.T) {
 	Convey("List Services", t, func() {
-		setup(MockRoute{"GET", "/v2/services", listServicePayload})
+		setup(MockRoute{"GET", "/v2/services", listServicePayload, ""}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,

--- a/spaces_test.go
+++ b/spaces_test.go
@@ -9,10 +9,10 @@ import (
 func TestListSpaces(t *testing.T) {
 	Convey("List Space", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/spaces", listSpacesPayload},
-			{"GET", "/v2/spacesPage2", listSpacesPayloadPage2},
+			{"GET", "/v2/spaces", listSpacesPayload, ""},
+			{"GET", "/v2/spacesPage2", listSpacesPayloadPage2, ""},
 		}
-		setupMultiple(mocks)
+		setupMultiple(mocks, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -38,7 +38,7 @@ func TestListSpaces(t *testing.T) {
 
 func TestSpaceOrg(t *testing.T) {
 	Convey("Find space org", t, func() {
-		setup(MockRoute{"GET", "/v2/org/foobar", orgPayload})
+		setup(MockRoute{"GET", "/v2/org/foobar", orgPayload, ""}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,


### PR DESCRIPTION
Adding options for User Agent
We should be able now to specify the user agent within the configuration


```golang
	c := &Config{
			ApiAddress: server.URL,
			Token:      "foobar",
			UserAgent:  "Test-golang",
		}
```


I clean a little string printout :p 
