### PR TITLE
Adding ability to query for app status.

### DIFF
--- a/apps_test.go
+++ b/apps_test.go
@@ -131,7 +131,7 @@ func TestGetAppInstances(t *testing.T) {
 
 func TestGetAppStats(t *testing.T) {
 	Convey("App stats completely running", t, func() {
-		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/stats", appStatsPayload})
+		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/stats", appStatsPayload, ""}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,

--- a/apps_test.go
+++ b/apps_test.go
@@ -2,6 +2,7 @@ package cfclient
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -86,6 +87,17 @@ func TestGetAppInstances(t *testing.T) {
 
 		So(appInstances["0"].State, ShouldEqual, "RUNNING")
 		So(appInstances["1"].State, ShouldEqual, "RUNNING")
+
+		var d0 float64 = 1455210430.5104606
+		var d1 float64 = 1455210430.3912115
+		date0 := time.Unix(int64(d0), 0)
+		date1 := time.Unix(int64(d1), 0)
+
+		So(appInstances["0"].Since.Format(time.UnixDate), ShouldEqual, date0.Format(time.UnixDate))
+		So(appInstances["1"].Since.Format(time.UnixDate), ShouldEqual, date1.Format(time.UnixDate))
+		So(appInstances["0"].Since.ToTime(), ShouldHaveSameTypeAs, date0)
+		So(appInstances["1"].Since.ToTime(), ShouldHaveSameTypeAs, date1)
+
 	})
 
 	Convey("App partially running", t, func() {
@@ -103,6 +115,51 @@ func TestGetAppInstances(t *testing.T) {
 
 		So(appInstances["0"].State, ShouldEqual, "RUNNING")
 		So(appInstances["1"].State, ShouldEqual, "STARTING")
+
+		var d0 float64 = 1455210430.5104606
+		var d1 float64 = 1455210430.3912115
+		date0 := time.Unix(int64(d0), 0)
+		date1 := time.Unix(int64(d1), 0)
+
+		So(appInstances["0"].Since.Format(time.UnixDate), ShouldEqual, date0.Format(time.UnixDate))
+		So(appInstances["1"].Since.Format(time.UnixDate), ShouldEqual, date1.Format(time.UnixDate))
+		So(appInstances["0"].Since.ToTime(), ShouldHaveSameTypeAs, date0)
+		So(appInstances["1"].Since.ToTime(), ShouldHaveSameTypeAs, date1)
+
+	})
+}
+
+func TestGetAppStats(t *testing.T) {
+	Convey("App stats completely running", t, func() {
+		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/stats", appStatsPayload})
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		appStats, err := client.GetAppStats("9902530c-c634-4864-a189-71d763cb12e2")
+		So(err, ShouldBeNil)
+
+		So(appStats["0"].State, ShouldEqual, "RUNNING")
+		So(appStats["1"].State, ShouldEqual, "RUNNING")
+
+		date0, _ := time.Parse("2006-01-02 15:04:05 -0700", "2016-09-17 15:46:17 +0000")
+		date1, _ := time.Parse("2006-01-02 15:04:05 -0700", "2016-09-17 15:46:17 +0000")
+
+		So(appStats["0"].Stats.Usage.Time.Format(time.UnixDate), ShouldEqual, date0.Format(time.UnixDate))
+		So(appStats["1"].Stats.Usage.Time.Format(time.UnixDate), ShouldEqual, date1.Format(time.UnixDate))
+		So(appStats["0"].Stats.Usage.Time.ToTime(), ShouldHaveSameTypeAs, date0)
+		So(appStats["1"].Stats.Usage.Time.ToTime(), ShouldHaveSameTypeAs, date1)
+		So(appStats["0"].Stats.Usage.CPU, ShouldEqual, 0.36580239597146486)
+		So(appStats["1"].Stats.Usage.CPU, ShouldEqual, 0.33857742931636664)
+		So(appStats["0"].Stats.Usage.Mem, ShouldEqual, 518123520)
+		So(appStats["1"].Stats.Usage.Mem, ShouldEqual, 530731008)
+		So(appStats["0"].Stats.Usage.Disk, ShouldEqual, 151150592)
+		So(appStats["1"].Stats.Usage.Disk, ShouldEqual, 151150592)
+
 	})
 }
 

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -597,6 +597,53 @@ const appInstanceUnhealthyPayload = `{
    }
 }`
 
+const appStatsPayload = `{
+   "0": {
+      "state": "RUNNING",
+      "stats": {
+         "name": "example-app",
+         "uris": [
+            "example-app.example.com",
+            "example-app-route2.example.com"
+         ],
+         "host": "192.168.1.100",
+         "port": 61297,
+         "uptime": 411118,
+         "mem_quota": 536870912,
+         "disk_quota": 1073741824,
+         "fds_quota": 16384,
+         "usage": {
+            "time": "2016-09-17 15:46:17 +0000",
+            "cpu": 0.36580239597146486,
+            "mem": 518123520,
+            "disk": 151150592
+         }
+      }
+   },
+   "1": {
+      "state": "RUNNING",
+      "stats": {
+         "name": "example-app",
+         "uris": [
+            "example-app.example.com",
+            "example-app-route2.example.com"
+         ],
+         "host": "192.168.1.101",
+         "port": 61388,
+         "uptime": 419568,
+         "mem_quota": 536870912,
+         "disk_quota": 1073741824,
+         "fds_quota": 16384,
+         "usage": {
+            "time": "2016-09-17 15:46:17 +0000",
+            "cpu": 0.33857742931636664,
+            "mem": 530731008,
+            "disk": 151150592
+         }
+      }
+   }
+}`
+
 const spacePayload = `{
    "metadata": {
       "guid": "a72fa1e8-c694-47b3-85f2-55f61fd00d73",
@@ -717,6 +764,7 @@ const listServicePayload = `{
       }
    ]
 }`
+
 const listAppsCreatedEventPayload = `{
    "total_results": 2,
    "total_pages": 2,


### PR DESCRIPTION
This PR adds support for the [`stats`](https://apidocs.cloudfoundry.org/251/apps/get_detailed_stats_for_a_started_app.html) endpoint of the Apps API by adding the `AppStats` type  and `GetAppStats` function.