### PR TITLE
[WIP] Add query parameters to list services.

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/url"
 	"strconv"
 	"time"
 )
@@ -120,10 +121,10 @@ func (a *App) Space() (Space, error) {
 	return spaceResource.Entity, nil
 }
 
-func (c *Client) ListApps() ([]App, error) {
+func (c *Client) ListAppsByQuery(query url.Values) ([]App, error) {
 	var apps []App
 
-	requestUrl := "/v2/apps?inline-relations-depth=2"
+	requestUrl := "/v2/apps?" + query.Encode()
 	for {
 		var appResp AppResponse
 		r := c.NewRequest("GET", requestUrl)
@@ -156,6 +157,12 @@ func (c *Client) ListApps() ([]App, error) {
 		}
 	}
 	return apps, nil
+}
+
+func (c *Client) ListApps() ([]App, error) {
+	q := url.Values{}
+	q.Set("inline-relations-depth", "2")
+	return c.ListAppsByQuery(q)
 }
 
 func (c *Client) GetAppInstances(guid string) (map[string]AppInstance, error) {

--- a/client.go
+++ b/client.go
@@ -262,11 +262,3 @@ func (c *Client) GetToken() (string, error) {
 	}
 	return "bearer " + token.AccessToken, nil
 }
-
-func setupQuery(query map[string]string) string {
-	q := "q="
-	for key, val := range query {
-		q += key + ":" + val + "&q="
-	}
-	return q
-}

--- a/services.go
+++ b/services.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 )
 
 type servicesResponse struct {
@@ -23,10 +24,10 @@ type Service struct {
 	c     *Client
 }
 
-func (c *Client) ListServices() ([]Service, error) {
+func (c *Client) ListServices(values url.Values) ([]Service, error) {
 	var services []Service
 	var serviceResp servicesResponse
-	r := c.NewRequest("GET", "/v2/services")
+	r := c.NewRequest("GET", "/v2/services?"+values.Encode())
 	resp, err := c.DoRequest(r)
 	if err != nil {
 		return nil, fmt.Errorf("Error requesting services %v", err)

--- a/services.go
+++ b/services.go
@@ -24,10 +24,10 @@ type Service struct {
 	c     *Client
 }
 
-func (c *Client) ListServices(values url.Values) ([]Service, error) {
+func (c *Client) ListServicesByQuery(query url.Values) ([]Service, error) {
 	var services []Service
 	var serviceResp servicesResponse
-	r := c.NewRequest("GET", "/v2/services?"+values.Encode())
+	r := c.NewRequest("GET", "/v2/services?"+query.Encode())
 	resp, err := c.DoRequest(r)
 	if err != nil {
 		return nil, fmt.Errorf("Error requesting services %v", err)
@@ -47,4 +47,8 @@ func (c *Client) ListServices(values url.Values) ([]Service, error) {
 		services = append(services, service.Entity)
 	}
 	return services, nil
+}
+
+func (c *Client) ListServices(query url.Values) ([]Service, error) {
+	return c.ListServicesByQuery(nil)
 }

--- a/services_test.go
+++ b/services_test.go
@@ -17,7 +17,7 @@ func TestListServices(t *testing.T) {
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 
-		services, err := client.ListServices()
+		services, err := client.ListServices(nil)
 		So(err, ShouldBeNil)
 
 		So(len(services), ShouldEqual, 2)

--- a/spaces.go
+++ b/spaces.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 )
 
 type SpaceResponse struct {
@@ -47,9 +48,9 @@ func (s *Space) Org() (Org, error) {
 	return orgResource.Entity, nil
 }
 
-func (c *Client) ListSpacesByQuery(query map[string]string) ([]Space, error) {
+func (c *Client) ListSpacesByQuery(query url.Values) ([]Space, error) {
 	var spaces []Space
-	requestUrl := "/v2/spaces?" + setupQuery(query)
+	requestUrl := "/v2/spaces?" + query.Encode()
 	for {
 		spaceResp, err := c.getSpaceResponse(requestUrl)
 		if err != nil {


### PR DESCRIPTION
Part of #42. If this pattern of passing a `url.Values` makes sense, I'll apply it to other list methods that take query parameters. We could also pass a string if that's clear. Or, to preserve backwards compatibility, `...string` or `...Option`, so that these methods can still be called with no arguments. WDYT?