### PR TITLE
Use default transport with additional TLS config

### DIFF
--- a/client.go
+++ b/client.go
@@ -99,14 +99,10 @@ func NewClient(config *Config) (client *Client, err error) {
 		config.UserAgent = defConfig.UserAgent
 	}
 	ctx := context.Background()
-	if config.SkipSslValidation == false {
-		ctx = context.WithValue(ctx, oauth2.HTTPClient, defConfig.HttpClient)
-	} else {
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: tr})
-	}
+
+	tr := http.DefaultTransport.(*http.Transport)
+	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: config.SkipSslValidation}
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: tr})
 
 	endpoint, err := getInfo(config.ApiAddress, oauth2.NewClient(ctx, nil))
 
@@ -182,7 +178,6 @@ func getUserTokenAuth(config *Config, endpoint *Endpoint, ctx context.Context) *
 	token := &oauth2.Token{
 		AccessToken: config.Token,
 		TokenType:   "Bearer"}
-
 
 	config.TokenSource = authConfig.TokenSource(ctx, token)
 	config.HttpClient = oauth2.NewClient(ctx, config.TokenSource)


### PR DESCRIPTION
`http.DefaultTransport` gives some handy default proxy settings that can be configured by standard env variables like `NO_PROXY` and `HTTPS_PROXY`. Setting it to a new Transport struct instance does not allow proxies to be injected externally. `TLSClientConfig` can still be assigned to DefaultTransport to allow skipping ssl validation.

Also, the if condition can be squashed by passing `SkipSslValidation` bool straight to `tls.Config` instance