### PR TITLE
now using proper status code

### DIFF
--- a/secgroups.go
+++ b/secgroups.go
@@ -218,7 +218,7 @@ func (c *Client) BindRunningSecGroup(secGUID string) error {
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != 201 { //201 Created
+	if resp.StatusCode != 200 { //200
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -234,7 +234,7 @@ func (c *Client) BindStagingSecGroup(secGUID string) error {
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != 201 { //201 Created
+	if resp.StatusCode != 200 { //200
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil


### PR DESCRIPTION
Per these docs:

https://apidocs.cloudfoundry.org/252/security_group_running_defaults/return_the_security_groups_used_for_running_apps.html

https://apidocs.cloudfoundry.org/241/security_group_staging_defaults/set_a_security_group_as_a_default_for_staging.html

The status code returned is 200 not 201, I have also tested this behavior with a simple app and have confirmed that CF does indeed return a 200 on a successful request.