### PR TITLE
Add http.Client Timeout as config parameter

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"time"
 
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
@@ -37,7 +36,6 @@ type Config struct {
 	ClientSecret      string `json:"client_secret"`
 	SkipSslValidation bool   `json:"skip_ssl_validation"`
 	HttpClient        *http.Client
-	Timeout           time.Duration `json:"timeout"`
 	Token             string        `json:"auth_token"`
 	TokenSource       oauth2.TokenSource
 	UserAgent         string `json:"user_agent"`
@@ -80,7 +78,6 @@ func DefaultEndpoint() *Endpoint {
 func NewClient(config *Config) (client *Client, err error) {
 	// bootstrap the config
 	defConfig := DefaultConfig()
-
 	if len(config.ApiAddress) == 0 {
 		config.ApiAddress = defConfig.ApiAddress
 	}
@@ -100,11 +97,17 @@ func NewClient(config *Config) (client *Client, err error) {
 	if len(config.UserAgent) == 0 {
 		config.UserAgent = defConfig.UserAgent
 	}
+
+	if config.HttpClient == nil {
+		config.HttpClient = defConfig.HttpClient
+	}
+	// keep track of the timeout specified via config
+	timeout := config.HttpClient.Timeout
 	ctx := context.Background()
 
 	tr := http.DefaultTransport.(*http.Transport)
 	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: config.SkipSslValidation}
-	ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: tr, Timeout: config.Timeout})
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: tr, Timeout: timeout})
 
 	endpoint, err := getInfo(config.ApiAddress, oauth2.NewClient(ctx, nil))
 
@@ -123,7 +126,8 @@ func NewClient(config *Config) (client *Client, err error) {
 			return nil, err
 		}
 	}
-
+	// make sure timeout will be set to what was initially specified in config
+	config.HttpClient.Timeout = timeout
 	client = &Client{
 		config:   *config,
 		Endpoint: *endpoint,
@@ -239,7 +243,6 @@ func (c *Client) DoRequest(r *request) (*http.Response, error) {
 	if r.body != nil {
 		req.Header.Set("Content-type", "application/json")
 	}
-
 	resp, err := c.config.HttpClient.Do(req)
 	return resp, err
 }

--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
@@ -36,7 +37,8 @@ type Config struct {
 	ClientSecret      string `json:"client_secret"`
 	SkipSslValidation bool   `json:"skip_ssl_validation"`
 	HttpClient        *http.Client
-	Token             string `json:"auth_token"`
+	Timeout           time.Duration `json:"timeout"`
+	Token             string        `json:"auth_token"`
 	TokenSource       oauth2.TokenSource
 	UserAgent         string `json:"user_agent"`
 }
@@ -102,7 +104,7 @@ func NewClient(config *Config) (client *Client, err error) {
 
 	tr := http.DefaultTransport.(*http.Transport)
 	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: config.SkipSslValidation}
-	ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: tr})
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: tr, Timeout: config.Timeout})
 
 	endpoint, err := getInfo(config.ApiAddress, oauth2.NewClient(ctx, nil))
 

--- a/client_test.go
+++ b/client_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/onsi/gomega"
 	. "github.com/smartystreets/goconvey/convey"
+	"net/http"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -41,14 +42,14 @@ func TestMakeRequest(t *testing.T) {
 
 func TestMakeRequestWithTimeout(t *testing.T) {
 	Convey("Test making request with timeout set", t, func() {
-		setupMultiple([]MockRoute{}, t)
+		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, "", 200}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress:        server.URL,
 			Username:          "foo",
 			Password:          "bar",
 			SkipSslValidation: true,
-			Timeout:           time.Duration(10),
+			HttpClient: &http.Client{Timeout: time.Duration(10)},
 		}
 		client, err := NewClient(c)
 		So(err, ShouldNotBeNil)

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package cfclient
 
 import (
 	"testing"
+	"time"
 
 	"github.com/onsi/gomega"
 	. "github.com/smartystreets/goconvey/convey"
@@ -35,6 +36,23 @@ func TestMakeRequest(t *testing.T) {
 		resp, err := client.DoRequest(req)
 		So(err, ShouldBeNil)
 		So(resp, ShouldNotBeNil)
+	})
+}
+
+func TestMakeRequestWithTimeout(t *testing.T) {
+	Convey("Test making request with timeout set", t, func() {
+		setupMultiple([]MockRoute{}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress:        server.URL,
+			Username:          "foo",
+			Password:          "bar",
+			SkipSslValidation: true,
+			Timeout:           time.Duration(10),
+		}
+		client, err := NewClient(c)
+		So(err, ShouldNotBeNil)
+		So(client, ShouldBeNil)
 	})
 }
 


### PR DESCRIPTION
We have seen issues in some deployments where calls to the CF CC took too long. 

Being able to specify a timeout on http.Client would allow us to better mitigate such issues.