### PR TITLE
Reuse config.HttpClient in cfclient.NewClient

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/onsi/gomega"
 	. "github.com/smartystreets/goconvey/convey"
+	"net/http"
+	"time"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -35,6 +37,23 @@ func TestMakeRequest(t *testing.T) {
 		resp, err := client.DoRequest(req)
 		So(err, ShouldBeNil)
 		So(resp, ShouldNotBeNil)
+	})
+}
+
+func TestMakeRequestWithTimeout(t *testing.T) {
+	Convey("Test making request b", t, func() {
+		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, "", 200}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress:        server.URL,
+			Username:          "foo",
+			Password:          "bar",
+			SkipSslValidation: true,
+			HttpClient: 	&http.Client{Timeout: 10 * time.Nanosecond},
+		}
+		client, err := NewClient(c)
+		So(err, ShouldNotBeNil)
+		So(client, ShouldBeNil)
 	})
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -42,14 +42,14 @@ func TestMakeRequest(t *testing.T) {
 
 func TestMakeRequestWithTimeout(t *testing.T) {
 	Convey("Test making request b", t, func() {
-		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, "", 200}, t)
+		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, "", 200, ""}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress:        server.URL,
 			Username:          "foo",
 			Password:          "bar",
 			SkipSslValidation: true,
-			HttpClient: 	&http.Client{Timeout: 10 * time.Nanosecond},
+			HttpClient:        &http.Client{Timeout: 10 * time.Nanosecond},
 		}
 		client, err := NewClient(c)
 		So(err, ShouldNotBeNil)


### PR DESCRIPTION
This allows callers to specify non-default values in config, e.g. a
non-zero http.Client.Timeout value to support non-blocking API calls.

While this could also be applied to the TLSClientConfig settings, SkipSslValidation
has been kept in cfclient.Config to remain backward-compatible.

This pull request supersedes [PR #81]