### PR TITLE
Expose org methods on client.

### DIFF
--- a/orgs.go
+++ b/orgs.go
@@ -206,6 +206,66 @@ func (o *Org) Quota() (*OrgQuota, error) {
 	return orgQuota, nil
 }
 
+func (c *Client) AssociateManager(orgGUID, userGUID string) (Org, error) {
+	org := Org{Guid: orgGUID, c: c}
+	return org.AssociateManager(userGUID)
+}
+
+func (c *Client) AssociateManagerByUsername(orgGUID, name string) (Org, error) {
+	org := Org{Guid: orgGUID, c: c}
+	return org.AssociateManagerByUsername(name)
+}
+
+func (c *Client) AssociateUser(orgGUID, userGUID string) (Org, error) {
+	org := Org{Guid: orgGUID, c: c}
+	return org.AssociateUser(userGUID)
+}
+
+func (c *Client) AssociateAuditor(orgGUID, userGUID string) (Org, error) {
+	org := Org{Guid: orgGUID, c: c}
+	return org.AssociateAuditor(userGUID)
+}
+
+func (c *Client) AssociateUserByUsername(orgGUID, name string) (Org, error) {
+	org := Org{Guid: orgGUID, c: c}
+	return org.AssociateUserByUsername(name)
+}
+
+func (c *Client) AssociateAuditorByUsername(orgGUID, name string) (Org, error) {
+	org := Org{Guid: orgGUID, c: c}
+	return org.AssociateAuditorByUsername(name)
+}
+
+func (c *Client) RemoveManager(orgGUID, userGUID string) error {
+	org := Org{Guid: orgGUID, c: c}
+	return org.RemoveManager(userGUID)
+}
+
+func (c *Client) RemoveManagerByUsername(orgGUID, name string) error {
+	org := Org{Guid: orgGUID, c: c}
+	return org.RemoveManagerByUsername(name)
+}
+
+func (c *Client) RemoveUser(orgGUID, userGUID string) error {
+	org := Org{Guid: orgGUID, c: c}
+	return org.RemoveUser(userGUID)
+}
+
+func (c *Client) RemoveAuditor(orgGUID, userGUID string) error {
+	org := Org{Guid: orgGUID, c: c}
+	return org.RemoveAuditor(userGUID)
+}
+
+func (c *Client) RemoveUserByUsername(orgGUID, name string) error {
+	org := Org{Guid: orgGUID, c: c}
+	return org.RemoveUserByUsername(name)
+}
+
+func (c *Client) RemoveAuditorByUsername(orgGUID, name string) error {
+	org := Org{Guid: orgGUID, c: c}
+	return org.RemoveAuditorByUsername(name)
+}
+
 func (o *Org) AssociateManager(userGUID string) (Org, error) {
 	requestUrl := fmt.Sprintf("/v2/organizations/%s/managers/%s", o.Guid, userGUID)
 	r := o.c.NewRequest("PUT", requestUrl)

--- a/orgs.go
+++ b/orgs.go
@@ -206,62 +206,62 @@ func (o *Org) Quota() (*OrgQuota, error) {
 	return orgQuota, nil
 }
 
-func (c *Client) AssociateManager(orgGUID, userGUID string) (Org, error) {
+func (c *Client) AssociateOrgManager(orgGUID, userGUID string) (Org, error) {
 	org := Org{Guid: orgGUID, c: c}
 	return org.AssociateManager(userGUID)
 }
 
-func (c *Client) AssociateManagerByUsername(orgGUID, name string) (Org, error) {
+func (c *Client) AssociateOrgManagerByUsername(orgGUID, name string) (Org, error) {
 	org := Org{Guid: orgGUID, c: c}
 	return org.AssociateManagerByUsername(name)
 }
 
-func (c *Client) AssociateUser(orgGUID, userGUID string) (Org, error) {
+func (c *Client) AssociateOrgUser(orgGUID, userGUID string) (Org, error) {
 	org := Org{Guid: orgGUID, c: c}
 	return org.AssociateUser(userGUID)
 }
 
-func (c *Client) AssociateAuditor(orgGUID, userGUID string) (Org, error) {
+func (c *Client) AssociateOrgAuditor(orgGUID, userGUID string) (Org, error) {
 	org := Org{Guid: orgGUID, c: c}
 	return org.AssociateAuditor(userGUID)
 }
 
-func (c *Client) AssociateUserByUsername(orgGUID, name string) (Org, error) {
+func (c *Client) AssociateOrgUserByUsername(orgGUID, name string) (Org, error) {
 	org := Org{Guid: orgGUID, c: c}
 	return org.AssociateUserByUsername(name)
 }
 
-func (c *Client) AssociateAuditorByUsername(orgGUID, name string) (Org, error) {
+func (c *Client) AssociateOrgAuditorByUsername(orgGUID, name string) (Org, error) {
 	org := Org{Guid: orgGUID, c: c}
 	return org.AssociateAuditorByUsername(name)
 }
 
-func (c *Client) RemoveManager(orgGUID, userGUID string) error {
+func (c *Client) RemoveOrgManager(orgGUID, userGUID string) error {
 	org := Org{Guid: orgGUID, c: c}
 	return org.RemoveManager(userGUID)
 }
 
-func (c *Client) RemoveManagerByUsername(orgGUID, name string) error {
+func (c *Client) RemoveOrgManagerByUsername(orgGUID, name string) error {
 	org := Org{Guid: orgGUID, c: c}
 	return org.RemoveManagerByUsername(name)
 }
 
-func (c *Client) RemoveUser(orgGUID, userGUID string) error {
+func (c *Client) RemoveOrgUser(orgGUID, userGUID string) error {
 	org := Org{Guid: orgGUID, c: c}
 	return org.RemoveUser(userGUID)
 }
 
-func (c *Client) RemoveAuditor(orgGUID, userGUID string) error {
+func (c *Client) RemoveOrgAuditor(orgGUID, userGUID string) error {
 	org := Org{Guid: orgGUID, c: c}
 	return org.RemoveAuditor(userGUID)
 }
 
-func (c *Client) RemoveUserByUsername(orgGUID, name string) error {
+func (c *Client) RemoveOrgUserByUsername(orgGUID, name string) error {
 	org := Org{Guid: orgGUID, c: c}
 	return org.RemoveUserByUsername(name)
 }
 
-func (c *Client) RemoveAuditorByUsername(orgGUID, name string) error {
+func (c *Client) RemoveOrgAuditorByUsername(orgGUID, name string) error {
 	org := Org{Guid: orgGUID, c: c}
 	return org.RemoveAuditorByUsername(name)
 }

--- a/spaces.go
+++ b/spaces.go
@@ -185,7 +185,26 @@ func (c *Client) CreateSpace(req SpaceRequest) (Space, error) {
 		return Space{}, fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return c.handleSpaceResp(resp)
+}
 
+func (c *Client) AssociateSpaceDeveloperByUsername(spaceGUID, name string) (Space, error) {
+	space := Space{Guid: spaceGUID, c: c}
+	return space.AssociateDeveloperByUsername(name)
+}
+
+func (c *Client) RemoveSpaceDeveloperByUsername(spaceGUID, name string) error {
+	space := Space{Guid: spaceGUID, c: c}
+	return space.RemoveDeveloperByUsername(name)
+}
+
+func (c *Client) AssociateSpaceAuditorByUsername(spaceGUID, name string) (Space, error) {
+	space := Space{Guid: spaceGUID, c: c}
+	return space.AssociateAuditorByUsername(name)
+}
+
+func (c *Client) RemoveSpaceAuditorByUsername(spaceGUID, name string) error {
+	space := Space{Guid: spaceGUID, c: c}
+	return space.RemoveAuditorByUsername(name)
 }
 
 func (s *Space) AssociateDeveloperByUsername(name string) (Space, error) {


### PR DESCRIPTION
I would like to be able to associate and dissociate users from orgs without making a request for an org, so I aliased the relevant methods of `Org` to `Client`. Alternatively, we could add a `Client.NewOrg` method that returns a new `Org` struct without calling the API, like this:

```go
func (c *Client) NewOrg(guid string) {
        return Org{Guid: guid, c: c}
}
```

so that I can use `client.NewOrg(orgGUID).AssociateUser(userGUID)`.

WDYT @jcscottiii @lnguyen ?