### PR TITLE
Make HttpClient use a copy of DefaultTransport

### DIFF
--- a/client.go
+++ b/client.go
@@ -104,8 +104,7 @@ func NewClient(config *Config) (client *Client, err error) {
 	}
 
 	if config.HttpClient.Transport == nil {
-		tr := *http.DefaultTransport.(*http.Transport)
-		config.HttpClient.Transport = &tr
+		config.HttpClient.Transport = shallowDefaultTransport()
 	}
 
 	tp := config.HttpClient.Transport.(*http.Transport)
@@ -147,6 +146,18 @@ func NewClient(config *Config) (client *Client, err error) {
 		Endpoint: *endpoint,
 	}
 	return client, nil
+}
+
+func shallowDefaultTransport() *http.Transport {
+	defaultTransport := http.DefaultTransport.(*http.Transport)
+	return &http.Transport{
+		Proxy:                 defaultTransport.Proxy,
+		DialContext:           defaultTransport.DialContext,
+		MaxIdleConns:          defaultTransport.MaxIdleConns,
+		IdleConnTimeout:       defaultTransport.IdleConnTimeout,
+		TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
+		ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
+	}
 }
 
 func getUserAuth(config *Config, endpoint *Endpoint, ctx context.Context) (*Config, error) {

--- a/client.go
+++ b/client.go
@@ -152,9 +152,6 @@ func shallowDefaultTransport() *http.Transport {
 	defaultTransport := http.DefaultTransport.(*http.Transport)
 	return &http.Transport{
 		Proxy:                 defaultTransport.Proxy,
-		DialContext:           defaultTransport.DialContext,
-		MaxIdleConns:          defaultTransport.MaxIdleConns,
-		IdleConnTimeout:       defaultTransport.IdleConnTimeout,
 		TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
 		ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
 	}

--- a/client.go
+++ b/client.go
@@ -104,7 +104,8 @@ func NewClient(config *Config) (client *Client, err error) {
 	}
 
 	if config.HttpClient.Transport == nil {
-		config.HttpClient.Transport = http.DefaultTransport
+		tr := *http.DefaultTransport.(*http.Transport)
+		config.HttpClient.Transport = &tr
 	}
 
 	tp := config.HttpClient.Transport.(*http.Transport)


### PR DESCRIPTION
If the `config.HttpClient` uses `DefaultTransport` directly then any change to its properties applies to all instances of default `net/http.Client` as well. This PR proposes using a copy of `DefaultTransport` created by dereferencing the pointer so that any TLSClientConfig applies only to the go-cfclient and does not pollute the global namespace.