### PR TITLE
added support for time.RFC3339, time.RFC3339Nano in AppStats.Usage.Ti…

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -133,25 +133,18 @@ func (s *statTime) UnmarshalJSON(b []byte) (err error) {
 	if err != nil {
 		return err
 	}
-	// RFC3339 time format
-	if (string(timeString[10]) == "T" && string(timeString[19]) == "Z"){
-		time, err := time.Parse("2006-01-02T15:04:05Z07:00", timeString)
-		if err != nil {
-			return err
+
+	possibleFormats := [...]string{time.RFC3339, time.RFC3339Nano, "2006-01-02 15:04:05 -0700"}
+
+	var value time.Time
+	for _, possibleFormat := range possibleFormats {
+		if value, err = time.Parse(possibleFormat, timeString); err == nil {
+			*s = statTime{value}
+			return nil
 		}
-		*s = statTime{time}
-	// Unix epoch time format
-	} else {
-		time, err := time.Parse("2006-01-02 15:04:05 -0700", timeString)
-		if err != nil {
-			return err
-		}
-		*s = statTime{time}
 	}
-	if err != nil {
-		return err
-	}
-	return nil
+
+	return fmt.Errorf("%s was not in any of the expected Date Formats %v", timeString, possibleFormats)
 }
 
 func (s statTime) ToTime() time.Time {

--- a/apps_test.go
+++ b/apps_test.go
@@ -171,20 +171,27 @@ func TestGetAppStats(t *testing.T) {
 
 		So(appStats["0"].State, ShouldEqual, "RUNNING")
 		So(appStats["1"].State, ShouldEqual, "RUNNING")
+		So(appStats["2"].State, ShouldEqual, "RUNNING")
 
 		date0, _ := time.Parse("2006-01-02 15:04:05 -0700", "2016-09-17 15:46:17 +0000")
 		date1, _ := time.Parse("2006-01-02 15:04:05 -0700", "2016-09-17 15:46:17 +0000")
+		date2, _ := time.Parse(time.RFC3339Nano, "2017-04-06T20:32:19.273294439Z")
 
 		So(appStats["0"].Stats.Usage.Time.Format(time.UnixDate), ShouldEqual, date0.Format(time.UnixDate))
 		So(appStats["1"].Stats.Usage.Time.Format(time.RFC3339), ShouldEqual, date1.Format(time.RFC3339))
+		So(appStats["2"].Stats.Usage.Time.Format(time.RFC3339Nano), ShouldEqual, date2.Format(time.RFC3339Nano))
 		So(appStats["0"].Stats.Usage.Time.ToTime(), ShouldHaveSameTypeAs, date0)
 		So(appStats["1"].Stats.Usage.Time.ToTime(), ShouldHaveSameTypeAs, date1)
+		So(appStats["2"].Stats.Usage.Time.ToTime(), ShouldHaveSameTypeAs, date2)
 		So(appStats["0"].Stats.Usage.CPU, ShouldEqual, 0.36580239597146486)
 		So(appStats["1"].Stats.Usage.CPU, ShouldEqual, 0.33857742931636664)
+		So(appStats["2"].Stats.Usage.CPU, ShouldEqual, 0.33857742931636664)
 		So(appStats["0"].Stats.Usage.Mem, ShouldEqual, 518123520)
 		So(appStats["1"].Stats.Usage.Mem, ShouldEqual, 530731008)
+		So(appStats["2"].Stats.Usage.Mem, ShouldEqual, 530731008)
 		So(appStats["0"].Stats.Usage.Disk, ShouldEqual, 151150592)
 		So(appStats["1"].Stats.Usage.Disk, ShouldEqual, 151150592)
+		So(appStats["2"].Stats.Usage.Disk, ShouldEqual, 151150592)
 
 	})
 }

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -1180,6 +1180,28 @@ const appStatsPayload = `{
             "disk": 151150592
          }
       }
+   },
+   "2": {
+      "state": "RUNNING",
+      "stats": {
+         "name": "example-app",
+         "uris": [
+            "example-app.example.com",
+            "example-app-route2.example.com"
+         ],
+         "host": "192.168.1.102",
+         "port": 61389,
+         "uptime": 419568,
+         "mem_quota": 536870912,
+         "disk_quota": 1073741824,
+         "fds_quota": 16384,
+         "usage": {
+            "time": "2017-04-06T20:32:19.273294439Z",
+            "cpu": 0.33857742931636664,
+            "mem": 530731008,
+            "disk": 151150592
+         }
+      }
    }
 }`
 


### PR DESCRIPTION
…me field since actual values from a running instance of Cloud Foundry have proven to return values in the RFC3339Nano format. Adjusted the UnmarshalJSON field for the custom sinceTime type so that it can allow for more formats to be attempted before giving up and erroring out. Added test conditions for this third time format