### PR TITLE
Adding support for isolation segments (PCF 1.10)

### DIFF
--- a/appevents_test.go
+++ b/appevents_test.go
@@ -9,8 +9,8 @@ import (
 func TestListAppEvents(t *testing.T) {
 	Convey("List App Events", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/events", listAppsCreatedEventPayload, "", 200, "q=type:audit.app.create"},
-			{"GET", "/v2/events2", listAppsCreatedEventPayload2, "", 200, ""},
+			{"GET", "/v2/events", listAppsCreatedEventPayload, "", 200, "q=type:audit.app.create", nil},
+			{"GET", "/v2/events2", listAppsCreatedEventPayload2, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -33,8 +33,8 @@ func TestListAppEvents(t *testing.T) {
 func TestListAppEventsByQuery(t *testing.T) {
 	Convey("List App Events By Query", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/events", listAppsCreatedEventPayload, "", 200, "q=type:audit.app.create&q=actee:3ca436ff-67a8-468a-8c7d-27ec68a6cfe5"},
-			{"GET", "/v2/events2", listAppsCreatedEventPayload2, "", 200, ""},
+			{"GET", "/v2/events", listAppsCreatedEventPayload, "", 200, "q=type:audit.app.create&q=actee:3ca436ff-67a8-468a-8c7d-27ec68a6cfe5", nil},
+			{"GET", "/v2/events2", listAppsCreatedEventPayload2, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()

--- a/apps_test.go
+++ b/apps_test.go
@@ -10,8 +10,8 @@ import (
 func TestListApps(t *testing.T) {
 	Convey("List Apps", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/apps", listAppsPayload, "Test-golang", 200, "inline-relations-depth=2"},
-			{"GET", "/v2/appsPage2", listAppsPayloadPage2, "Test-golang", 200, ""},
+			{"GET", "/v2/apps", listAppsPayload, "Test-golang", 200, "inline-relations-depth=2", nil},
+			{"GET", "/v2/appsPage2", listAppsPayloadPage2, "Test-golang", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -63,7 +63,7 @@ func TestListApps(t *testing.T) {
 
 func TestAppByGuid(t *testing.T) {
 	Convey("App By GUID", t, func() {
-		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2", appPayload, "", 200, "inline-relations-depth=2"}, t)
+		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2", appPayload, "", 200, "inline-relations-depth=2", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -80,7 +80,7 @@ func TestAppByGuid(t *testing.T) {
 	})
 
 	Convey("App By GUID with environment variables with different types", t, func() {
-		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2", appPayloadWithEnvironment_json, "", 200, "inline-relations-depth=2"}, t)
+		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2", appPayloadWithEnvironment_json, "", 200, "inline-relations-depth=2", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -99,7 +99,7 @@ func TestAppByGuid(t *testing.T) {
 
 func TestGetAppInstances(t *testing.T) {
 	Convey("App completely running", t, func() {
-		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/instances", appInstancePayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/instances", appInstancePayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -127,7 +127,7 @@ func TestGetAppInstances(t *testing.T) {
 	})
 
 	Convey("App partially running", t, func() {
-		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/instances", appInstanceUnhealthyPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/instances", appInstanceUnhealthyPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -157,7 +157,7 @@ func TestGetAppInstances(t *testing.T) {
 
 func TestGetAppStats(t *testing.T) {
 	Convey("App stats completely running", t, func() {
-		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/stats", appStatsPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/stats", appStatsPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -198,7 +198,7 @@ func TestGetAppStats(t *testing.T) {
 
 func TestGetAppRoutes(t *testing.T) {
 	Convey("List app routes", t, func() {
-		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/routes", appRoutesPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/routes", appRoutesPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -224,7 +224,7 @@ func TestGetAppRoutes(t *testing.T) {
 
 func TestKillAppInstance(t *testing.T) {
 	Convey("Kills an app instance", t, func() {
-		setup(MockRoute{"DELETE", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/instances/0", "", "", 204, ""}, t)
+		setup(MockRoute{"DELETE", "/v2/apps/9902530c-c634-4864-a189-71d763cb12e2/instances/0", "", "", 204, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -239,7 +239,7 @@ func TestKillAppInstance(t *testing.T) {
 
 func TestAppEnv(t *testing.T) {
 	Convey("Find app space", t, func() {
-		setup(MockRoute{"GET", "/v2/apps/a7c47787-a982-467c-95d7-9ab17cbcc918/env", appEnvPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/apps/a7c47787-a982-467c-95d7-9ab17cbcc918/env", appEnvPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -260,7 +260,7 @@ func TestAppEnv(t *testing.T) {
 
 func TestAppSpace(t *testing.T) {
 	Convey("Find app space", t, func() {
-		setup(MockRoute{"GET", "/v2/spaces/foobar", spacePayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/spaces/foobar", spacePayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,

--- a/buildpacks_test.go
+++ b/buildpacks_test.go
@@ -9,8 +9,8 @@ import (
 func TestListBuildpacks(t *testing.T) {
 	Convey("List buildpack", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/buildpacks", ListBuildpacksPayload, "", 200, ""},
-			{"GET", "/v2/buildpacksPage2", ListBuildpacksPayload2, "", 200, ""},
+			{"GET", "/v2/buildpacks", ListBuildpacksPayload, "", 200, "", nil},
+			{"GET", "/v2/buildpacksPage2", ListBuildpacksPayload2, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()

--- a/client_test.go
+++ b/client_test.go
@@ -23,7 +23,7 @@ func TestDefaultConfig(t *testing.T) {
 
 func TestMakeRequest(t *testing.T) {
 	Convey("Test making request b", t, func() {
-		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress:        server.URL,
@@ -42,7 +42,7 @@ func TestMakeRequest(t *testing.T) {
 
 func TestMakeRequestWithTimeout(t *testing.T) {
 	Convey("Test making request b", t, func() {
-		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress:        server.URL,
@@ -60,7 +60,7 @@ func TestMakeRequestWithTimeout(t *testing.T) {
 func TestTokenRefresh(t *testing.T) {
 	gomega.RegisterTestingT(t)
 	Convey("Test making request", t, func() {
-		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, "", 200, "", nil}, t)
 		c := &Config{
 			ApiAddress: server.URL,
 			Username:   "foo",

--- a/domains_test.go
+++ b/domains_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestListDomains(t *testing.T) {
 	Convey("List domains", t, func() {
-		setup(MockRoute{"GET", "/v2/private_domains", listDomainsPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/private_domains", listDomainsPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -31,7 +31,7 @@ func TestListDomains(t *testing.T) {
 
 func TestListSharedDomains(t *testing.T) {
 	Convey("List shared domains", t, func() {
-		setup(MockRoute{"GET", "/v2/shared_domains", listSharedDomainsPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/shared_domains", listSharedDomainsPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -53,7 +53,7 @@ func TestListSharedDomains(t *testing.T) {
 
 func TestCreateDomain(t *testing.T) {
 	Convey("Create domain", t, func() {
-		setup(MockRoute{"POST", "/v2/private_domains", postDomainPayload, "", 201, ""}, t)
+		setup(MockRoute{"POST", "/v2/private_domains", postDomainPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -71,7 +71,7 @@ func TestCreateDomain(t *testing.T) {
 
 func TestDeleteDomain(t *testing.T) {
 	Convey("Delete domain", t, func() {
-		setup(MockRoute{"DELETE", "/v2/private_domains/b2a35f0c-d5ad-4a59-bea7-461711d96b0d", "", "", 204, ""}, t)
+		setup(MockRoute{"DELETE", "/v2/private_domains/b2a35f0c-d5ad-4a59-bea7-461711d96b0d", "", "", 204, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,

--- a/isolationsegments.go
+++ b/isolationsegments.go
@@ -1,0 +1,241 @@
+package cfclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type IsolationSegment struct {
+	GUID      string    `json:"guid"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	c         *Client
+}
+
+type IsolationSegementResponse struct {
+	GUID      string    `json:"guid"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Links     struct {
+		Self struct {
+			Href string `json:"href"`
+		} `json:"self"`
+		Spaces struct {
+			Href string `json:"href"`
+		} `json:"spaces"`
+		Organizations struct {
+			Href string `json:"href"`
+		} `json:"organizations"`
+	} `json:"links"`
+}
+
+type Pagination struct {
+	TotalResults int `json:"total_results"`
+	TotalPages   int `json:"total_pages"`
+	First        struct {
+		Href string `json:"href"`
+	} `json:"first"`
+	Last struct {
+		Href string `json:"href"`
+	} `json:"last"`
+	Next     string `json:"next"`
+	Previous string `json:"previous"`
+}
+
+type ListIsolationSegmentsResponse struct {
+	Pagination Pagination                  `json:"pagination"`
+	Resources  []IsolationSegementResponse `json:"resources"`
+}
+
+func (c *Client) CreateIsolationSegment(name string) (*IsolationSegment, error) {
+	req := c.NewRequest("POST", "/v3/isolation_segments")
+	req.obj = map[string]interface{}{
+		"name": name,
+	}
+	resp, err := c.DoRequest(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error while creating isolation segment")
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return nil, errors.New(fmt.Sprintf("Error creating isolation segment %s, response code: %d", name, resp.StatusCode))
+	}
+	return respBodyToIsolationSegment(resp.Body, c)
+}
+
+func respBodyToIsolationSegment(body io.ReadCloser, c *Client) (*IsolationSegment, error) {
+	bodyRaw, err := ioutil.ReadAll(body)
+	if err != nil {
+		return nil, err
+	}
+	isr := IsolationSegementResponse{}
+	err = json.Unmarshal([]byte(bodyRaw), &isr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &IsolationSegment{
+		GUID:      isr.GUID,
+		Name:      isr.Name,
+		CreatedAt: isr.CreatedAt,
+		UpdatedAt: isr.UpdatedAt,
+		c:         c,
+	}, nil
+}
+
+func (c *Client) GetIsolationSegmentByGUID(guid string) (*IsolationSegment, error) {
+	var isr IsolationSegementResponse
+	r := c.NewRequest("GET", "/v3/isolation_segments/"+guid)
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error requesting isolation segment by GUID")
+	}
+	defer resp.Body.Close()
+	resBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error reading isolation segment response body")
+	}
+
+	err = json.Unmarshal(resBody, &isr)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error unmarshalling isolation segment response")
+	}
+	return &IsolationSegment{Name: isr.Name, GUID: isr.GUID, CreatedAt: isr.CreatedAt, UpdatedAt: isr.UpdatedAt, c: c}, nil
+}
+
+func (c *Client) ListIsolationSegments() ([]IsolationSegment, error) {
+	var iss []IsolationSegment
+	requestUrl := "/v3/isolation_segments"
+	for {
+		var isr ListIsolationSegmentsResponse
+		r := c.NewRequest("GET", requestUrl)
+		resp, err := c.DoRequest(r)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error requesting isolation segments")
+		}
+		defer resp.Body.Close()
+		resBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error reading isolation segment request")
+		}
+
+		err = json.Unmarshal(resBody, &isr)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error unmarshalling isolation segment")
+		}
+
+		for _, is := range isr.Resources {
+			iss = append(iss, IsolationSegment{
+				Name:      is.Name,
+				GUID:      is.GUID,
+				CreatedAt: is.CreatedAt,
+				UpdatedAt: is.UpdatedAt,
+				c:         c,
+			})
+		}
+
+		requestUrl = isr.Pagination.Next
+		if requestUrl == "" {
+			break
+		}
+	}
+	return iss, nil
+}
+
+// TODO listOrgsForIsolationSegments
+// TODO listSpacesForIsolationSegments
+// TODO setDefaultIsolationSegmentForOrg
+
+func (c *Client) DeleteIsolationSegmentByGUID(guid string) error {
+	resp, err := c.DoRequest(c.NewRequest("DELETE", fmt.Sprintf("/v3/isolation_segments/%s", guid)))
+	if err != nil {
+		return errors.Wrap(err, "Error during sending DELETE request for isolation segments")
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return errors.New(fmt.Sprintf("Error deleting isolation segment %s, response code: %d", guid, resp.StatusCode))
+	}
+	return nil
+}
+
+func (i *IsolationSegment) Delete() error {
+	return i.c.DeleteIsolationSegmentByGUID(i.GUID)
+}
+
+func (i *IsolationSegment) AddOrg(orgGuid string) error {
+	if i == nil || i.c == nil {
+		return errors.New("No communication handle.")
+	}
+	req := i.c.NewRequest("POST", fmt.Sprintf("/v3/isolation_segments/%s/relationships/organizations", i.GUID))
+	type Entry struct {
+		GUID string `json:"guid"`
+	}
+	req.obj = map[string]interface{}{
+		"data": []Entry{Entry{GUID: orgGuid}},
+	}
+	resp, err := i.c.DoRequest(req)
+	if err != nil {
+		return errors.Wrap(err, "Error during adding org to isolation segment")
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return errors.New(fmt.Sprintf("Error adding org %s to isolation segment %s, response code: %d", orgGuid, i.Name, resp.StatusCode))
+	}
+	return nil
+}
+
+func (i *IsolationSegment) RemoveOrg(orgGuid string) error {
+	if i == nil || i.c == nil {
+		return errors.New("No communication handle.")
+	}
+	req := i.c.NewRequest("DELETE", fmt.Sprintf("/v3/isolation_segments/%s/relationships/organizations", i.GUID))
+	req.obj = map[string]interface{}{
+		"guid": orgGuid,
+	}
+	resp, err := i.c.DoRequest(req)
+	if err != nil {
+		return errors.Wrapf(err, "Error during removing org %s in isolation segment %s", orgGuid, i.Name)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return errors.New(fmt.Sprintf("Error deleting org %s in isolation segment %s, response code: %d", orgGuid, i.Name, resp.StatusCode))
+	}
+	return nil
+}
+
+func (i *IsolationSegment) AddSpace(spaceGuid string) error {
+	if i == nil || i.c == nil {
+		return errors.New("No communication handle.")
+	}
+	req := i.c.NewRequest("PUT", fmt.Sprintf("/v2/spaces/%s", spaceGuid))
+	req.obj = map[string]interface{}{
+		"isolation_segment_guid": i.GUID,
+	}
+	resp, err := i.c.DoRequest(req)
+	if err != nil {
+		return errors.Wrapf(err, "Error during adding space %s to isolation segment %s", spaceGuid, i.Name)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return errors.New(fmt.Sprintf("Error adding space to isolation segment %s, response code: %d", i.Name, resp.StatusCode))
+	}
+	return nil
+}
+
+func (i *IsolationSegment) RemoveSpace(spaceGuid string) error {
+	if i == nil || i.c == nil {
+		return errors.New("No communication handle.")
+	}
+	req := i.c.NewRequest("DELETE", fmt.Sprintf("/v2/spaces/%s/isolation_segment", spaceGuid))
+	resp, err := i.c.DoRequest(req)
+	if err != nil {
+		return errors.Wrapf(err, "Error during deleting space %s in isolation segment %s", spaceGuid, i.Name)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return errors.New(fmt.Sprintf("Error deleting space %s from isolation segment %s, response code: %d", spaceGUID, i.Name, resp.StatusCode))
+	}
+	return nil
+}

--- a/isolationsegments_test.go
+++ b/isolationsegments_test.go
@@ -1,0 +1,176 @@
+package cfclient
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestCreateIsolationSegement(t *testing.T) {
+	Convey("Create Isolation Segment", t, func() {
+		mocks := []MockRoute{
+			{"POST", "/v3/isolation_segments", createIsolationSegmentPayload, "", http.StatusCreated, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		name := "TheKittenIsTheShark"
+
+		isolationsegment, err := client.CreateIsolationSegment(name)
+		So(err, ShouldBeNil)
+
+		So(isolationsegment.Name, ShouldEqual, name)
+		So(isolationsegment.GUID, ShouldEqual, "323f211e-fea3-4161-9bd1-615392327913")
+		So(isolationsegment.CreatedAt.String(), ShouldEqual, time.Date(2016, 10, 19, 20, 25, 04, 0, time.FixedZone("UTC", 0)).String())
+		So(isolationsegment.UpdatedAt.String(), ShouldEqual, time.Date(2016, 11, 8, 16, 41, 26, 0, time.FixedZone("UTC", 0)).String())
+	})
+}
+
+func TestGetIsolationSegementByGUID(t *testing.T) {
+	Convey("Request existing Isolation Segment", t, func() {
+		mocks := []MockRoute{
+			{"GET", "/v3/isolation_segments/323f211e-fea3-4161-9bd1-615392327913", createIsolationSegmentPayload, "", http.StatusOK, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		name := "TheKittenIsTheShark"
+
+		isolationsegment, err := client.GetIsolationSegmentByGUID("323f211e-fea3-4161-9bd1-615392327913")
+		So(err, ShouldBeNil)
+
+		So(isolationsegment.Name, ShouldEqual, name)
+		So(isolationsegment.GUID, ShouldEqual, "323f211e-fea3-4161-9bd1-615392327913")
+		So(isolationsegment.CreatedAt.String(), ShouldEqual, time.Date(2016, 10, 19, 20, 25, 04, 0, time.FixedZone("UTC", 0)).String())
+		So(isolationsegment.UpdatedAt.String(), ShouldEqual, time.Date(2016, 11, 8, 16, 41, 26, 0, time.FixedZone("UTC", 0)).String())
+	})
+
+	Convey("Request non-existing Isolation Segment", t, func() {
+		mocks := []MockRoute{
+			{"GET", "/v3/isolation_segments/323f211e-fea3-4161--9bd1-615392327913", createIsolationSegmentPayload, "", http.StatusOK, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		isolationsegment, err := client.GetIsolationSegmentByGUID("does not exit")
+		So(err, ShouldNotBeNil)
+		So(isolationsegment, ShouldBeNil)
+	})
+}
+
+func TestListIsolationSegments(t *testing.T) {
+	Convey("Request list of all Isolation Segments", t, func() {
+		mocks := []MockRoute{
+			{"GET", "/v3/isolation_segments", listIsolationSegmentsPayload, "", http.StatusOK, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		isolationsegment, err := client.ListIsolationSegments()
+		So(err, ShouldBeNil)
+		So(isolationsegment, ShouldNotBeNil)
+		So(len(isolationsegment), ShouldEqual, 2)
+
+		So(isolationsegment[0].Name, ShouldEqual, "shared")
+		So(isolationsegment[0].GUID, ShouldEqual, "033b4c58-12bb-499a-b05d-4b6fc9e2993b")
+		So(isolationsegment[0].CreatedAt.String(), ShouldEqual, time.Date(2017, 4, 2, 11, 22, 4, 0, time.FixedZone("UTC", 0)).String())
+		So(isolationsegment[0].UpdatedAt.String(), ShouldEqual, time.Date(2017, 4, 2, 11, 22, 4, 0, time.FixedZone("UTC", 0)).String())
+
+		So(isolationsegment[1].Name, ShouldEqual, "my_segment")
+		So(isolationsegment[1].GUID, ShouldEqual, "23d0baf4-9d3c-44d8-b2dc-1767bcdad1e0")
+		So(isolationsegment[1].CreatedAt.String(), ShouldEqual, time.Date(2017, 4, 7, 11, 20, 16, 0, time.FixedZone("UTC", 0)).String())
+		So(isolationsegment[1].UpdatedAt.String(), ShouldEqual, time.Date(2017, 4, 7, 11, 20, 16, 0, time.FixedZone("UTC", 0)).String())
+	})
+}
+
+func TestDeleteIsolationSegmentByGUID(t *testing.T) {
+	Convey("Delete an Isolation Segment by GUID", t, func() {
+		mocks := []MockRoute{
+			{"DELETE", "/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b", "", "", http.StatusNoContent, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		err = client.DeleteIsolationSegmentByGUID("033b4c58-12bb-499a-b05d-4b6fc9e2993b")
+		So(err, ShouldBeNil)
+
+		err = client.DeleteIsolationSegmentByGUID("theKittenIsTheShark")
+		So(err, ShouldNotBeNil)
+	})
+}
+
+func TestIsolationSegmentMethods(t *testing.T) {
+
+	postData := `{"data":[{"guid":"theKittenIsTheShark"}]}`
+
+	Convey("Request list of all Isolation Segments", t, func() {
+		mocks := []MockRoute{
+			{"GET", "/v3/isolation_segments", listIsolationSegmentsPayload, "", http.StatusOK, "", nil},
+			{"DELETE", "/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b", "", "", http.StatusNoContent, "", nil},
+			{"POST", "/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b/relationships/organizations", "", "", http.StatusCreated, "", &postData},
+			{"DELETE", "/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b/relationships/organizations", "", "", http.StatusNoContent, "", nil},
+			{"PUT", "/v2/spaces/theKittenIsTheShark", "", "", http.StatusCreated, "", nil},
+			{"DELETE", "/v2/spaces/theKittenIsTheShark/isolation_segment", "", "", http.StatusNoContent, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		isolationsegment, err := client.ListIsolationSegments()
+
+		So(err, ShouldBeNil)
+		So(isolationsegment, ShouldNotBeNil)
+		So(len(isolationsegment), ShouldEqual, 2)
+
+		errAddOrg := isolationsegment[0].AddOrg("theKittenIsTheShark")
+		So(errAddOrg, ShouldBeNil)
+
+		errRemOrg := isolationsegment[0].RemoveOrg("theKittenIsTheShark")
+		So(errRemOrg, ShouldBeNil)
+
+		errAddSpace := isolationsegment[0].AddSpace("theKittenIsTheShark")
+		So(errAddSpace, ShouldBeNil)
+
+		errRemSpace := isolationsegment[0].RemoveSpace("theKittenIsTheShark")
+		So(errRemSpace, ShouldBeNil)
+
+		errDel := isolationsegment[0].Delete()
+		So(errDel, ShouldBeNil)
+	})
+}

--- a/org_quotas_test.go
+++ b/org_quotas_test.go
@@ -9,8 +9,8 @@ import (
 func TestListOrgQuotas(t *testing.T) {
 	Convey("List Org Quotas", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/quota_definitions", listOrgQuotasPayloadPage1, "", 200, ""},
-			{"GET", "/v2/quota_definitions_page_2", listOrgQuotasPayloadPage2, "", 200, ""},
+			{"GET", "/v2/quota_definitions", listOrgQuotasPayloadPage1, "", 200, "", nil},
+			{"GET", "/v2/quota_definitions_page_2", listOrgQuotasPayloadPage2, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -43,7 +43,7 @@ func TestListOrgQuotas(t *testing.T) {
 
 func TestGetOrgQuotaByName(t *testing.T) {
 	Convey("Get Org Quota By Name", t, func() {
-		setup(MockRoute{"GET", "/v2/quota_definitions", listOrgQuotasPayloadPage2, "", 200, "q=name:default2"}, t)
+		setup(MockRoute{"GET", "/v2/quota_definitions", listOrgQuotasPayloadPage2, "", 200, "q=name:default2", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,

--- a/orgs_test.go
+++ b/orgs_test.go
@@ -9,8 +9,8 @@ import (
 func TestListOrgs(t *testing.T) {
 	Convey("List Org", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/organizations", listOrgsPayload, "", 200, ""},
-			{"GET", "/v2/orgsPage2", listOrgsPayloadPage2, "", 200, ""},
+			{"GET", "/v2/organizations", listOrgsPayload, "", 200, "", nil},
+			{"GET", "/v2/orgsPage2", listOrgsPayloadPage2, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -32,7 +32,7 @@ func TestListOrgs(t *testing.T) {
 
 func TestGetOrgByGuid(t *testing.T) {
 	Convey("List Org", t, func() {
-		setup(MockRoute{"GET", "/v2/organizations/1c0e6074-777f-450e-9abc-c42f39d9b75b", orgByGuidPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/organizations/1c0e6074-777f-450e-9abc-c42f39d9b75b", orgByGuidPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -51,7 +51,7 @@ func TestGetOrgByGuid(t *testing.T) {
 
 func TestOrgSpaces(t *testing.T) {
 	Convey("Get spaces by org", t, func() {
-		setup(MockRoute{"GET", "/v2/organizations/foo/spaces", orgSpacesPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/organizations/foo/spaces", orgSpacesPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -71,7 +71,7 @@ func TestOrgSpaces(t *testing.T) {
 
 func TestOrgSummary(t *testing.T) {
 	Convey("Get org summary", t, func() {
-		setup(MockRoute{"GET", "/v2/organizations/06dcedd4-1f24-49a6-adc1-cce9131a1b2c/summary", orgSummaryPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/organizations/06dcedd4-1f24-49a6-adc1-cce9131a1b2c/summary", orgSummaryPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -104,7 +104,7 @@ func TestOrgSummary(t *testing.T) {
 
 func TestOrgQuota(t *testing.T) {
 	Convey("Get org quota", t, func() {
-		setup(MockRoute{"GET", "/v2/quota_definitions/a537761f-9d93-4b30-af17-3d73dbca181b", orgQuotaPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/quota_definitions/a537761f-9d93-4b30-af17-3d73dbca181b", orgQuotaPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -138,7 +138,7 @@ func TestOrgQuota(t *testing.T) {
 
 func TestCreateOrg(t *testing.T) {
 	Convey("Create org", t, func() {
-		setup(MockRoute{"POST", "/v2/organizations", createOrgPayload, "", 201, ""}, t)
+		setup(MockRoute{"POST", "/v2/organizations", createOrgPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -155,7 +155,7 @@ func TestCreateOrg(t *testing.T) {
 
 func TestDeleteOrg(t *testing.T) {
 	Convey("Delete org", t, func() {
-		setup(MockRoute{"DELETE", "/v2/organizations/a537761f-9d93-4b30-af17-3d73dbca181b", "", "", 204, ""}, t)
+		setup(MockRoute{"DELETE", "/v2/organizations/a537761f-9d93-4b30-af17-3d73dbca181b", "", "", 204, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -171,7 +171,7 @@ func TestDeleteOrg(t *testing.T) {
 
 func TestAssociateManager(t *testing.T) {
 	Convey("Associate manager", t, func() {
-		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers/user-guid", associateOrgManagerPayload, "", 201, ""}, t)
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers/user-guid", associateOrgManagerPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -193,7 +193,7 @@ func TestAssociateManager(t *testing.T) {
 
 func TestAssociateAuditor(t *testing.T) {
 	Convey("Associate auditor", t, func() {
-		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors/user-guid", associateOrgAuditorPayload, "", 201, ""}, t)
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors/user-guid", associateOrgAuditorPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -215,7 +215,7 @@ func TestAssociateAuditor(t *testing.T) {
 
 func TestAssociateUser(t *testing.T) {
 	Convey("Associate user", t, func() {
-		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users/user-guid", associateOrgUserPayload, "", 201, ""}, t)
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users/user-guid", associateOrgUserPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -237,7 +237,7 @@ func TestAssociateUser(t *testing.T) {
 
 func TestAssociateManagerByUsername(t *testing.T) {
 	Convey("Associate manager by username", t, func() {
-		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers", associateOrgManagerPayload, "", 201, ""}, t)
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers", associateOrgManagerPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -259,7 +259,7 @@ func TestAssociateManagerByUsername(t *testing.T) {
 
 func TestAssociateAuditorByUsername(t *testing.T) {
 	Convey("Associate auditor by username", t, func() {
-		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", associateOrgAuditorPayload, "", 201, ""}, t)
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", associateOrgAuditorPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -281,7 +281,7 @@ func TestAssociateAuditorByUsername(t *testing.T) {
 
 func TestAssociateUserByUsername(t *testing.T) {
 	Convey("Associate user by username", t, func() {
-		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users", associateOrgUserPayload, "", 201, ""}, t)
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users", associateOrgUserPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -303,7 +303,7 @@ func TestAssociateUserByUsername(t *testing.T) {
 
 func TestRemoveManager(t *testing.T) {
 	Convey("Remove manager", t, func() {
-		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers/user-guid", "", "", 204, ""}, t)
+		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers/user-guid", "", "", 204, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -324,7 +324,7 @@ func TestRemoveManager(t *testing.T) {
 
 func TestRemoveAuditor(t *testing.T) {
 	Convey("Remove auditor", t, func() {
-		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors/user-guid", "", "", 204, ""}, t)
+		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors/user-guid", "", "", 204, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -345,7 +345,7 @@ func TestRemoveAuditor(t *testing.T) {
 
 func TestRemoveUser(t *testing.T) {
 	Convey("Remove user", t, func() {
-		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users/user-guid", "", "", 204, ""}, t)
+		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users/user-guid", "", "", 204, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -366,7 +366,7 @@ func TestRemoveUser(t *testing.T) {
 
 func TestRemoveManagerByUsername(t *testing.T) {
 	Convey("Remove manager by username", t, func() {
-		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers", "", "", 204, ""}, t)
+		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers", "", "", 204, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -387,7 +387,7 @@ func TestRemoveManagerByUsername(t *testing.T) {
 
 func TestRemoveAuditorByUsername(t *testing.T) {
 	Convey("Remove auditor by username", t, func() {
-		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", "", "", 204, ""}, t)
+		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", "", "", 204, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -408,7 +408,7 @@ func TestRemoveAuditorByUsername(t *testing.T) {
 
 func TestRemoveUserByUsername(t *testing.T) {
 	Convey("Remove user by username", t, func() {
-		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users", "", "", 204, ""}, t)
+		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users", "", "", 204, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -2212,3 +2212,90 @@ const createUserPayload = `{
     "audited_spaces_url": "/v2/users/guid-cb24b36d-4656-468e-a50d-b53113ac6177/audited_spaces"
   }
 }`
+
+const createIsolationSegmentPayload = `{
+   "guid": "323f211e-fea3-4161-9bd1-615392327913",
+   "name": "TheKittenIsTheShark",
+   "created_at": "2016-10-19T20:25:04Z",
+   "updated_at": "2016-11-08T16:41:26Z",
+   "links": {
+      "self": {
+         "href": "https://api.example.org/v3/isolation_segments/323f211e-fea3-4161-9bd1-615392327913"
+      },
+      "spaces": {
+         "href": "https://api.example.org/v3/isolation_segments/323f211e-fea3-4161-9bd1-615392327913/relationships/spaces"
+      },
+      "organizations": {
+         "href": "https://api.example.org/v3/isolation_segments/323f211e-fea3-4161-9bd1-615392327913/relationships/organizations"
+      }
+   }
+}`
+
+const listIsolationSegmentsPayload = `{
+   "pagination": {
+      "total_results": 2,
+      "total_pages": 1,
+      "first": {
+         "href": "https://api.example.org/v3/isolation_segments?page=1&per_page=50"
+      },
+      "last": {
+         "href": "https://api.example.org/v3/isolation_segments?page=1&per_page=50"
+      },
+      "next": null,
+      "previous": null
+   },
+   "resources": [
+      {
+         "guid": "033b4c58-12bb-499a-b05d-4b6fc9e2993b",
+         "name": "shared",
+         "created_at": "2017-04-02T11:22:04Z",
+         "updated_at": "2017-04-02T11:22:04Z",
+         "links": {
+            "self": {
+               "href": "https://api.example.org/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b"
+            },
+            "organizations": {
+               "href": "https://api.example.org/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b/organizations"
+            },
+            "spaces": {
+               "href": "https://api.example.org/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b/relationships/spaces"
+            }
+         }
+      },
+      {
+         "guid": "23d0baf4-9d3c-44d8-b2dc-1767bcdad1e0",
+         "name": "my_segment",
+         "created_at": "2017-04-07T11:20:16Z",
+         "updated_at": "2017-04-07T11:20:16Z",
+         "links": {
+            "self": {
+               "href": "https://api.example.org/v3/isolation_segments/23d0baf4-9d3c-44d8-b2dc-1767bcdad1e0"
+            },
+            "organizations": {
+               "href": "https://api.example.org/v3/isolation_segments/23d0baf4-9d3c-44d8-b2dc-1767bcdad1e0/organizations"
+            },
+            "spaces": {
+               "href": "https://api.example.org/v3/isolation_segments/23d0baf4-9d3c-44d8-b2dc-1767bcdad1e0/relationships/spaces"
+            }
+         }
+      }
+   ]
+}`
+
+const addOrgToIsolationSegmentPayload = `{
+   "guid": "033b4c58-12bb-499a-b05d-4b6fc9e2993b",
+   "name": "shared",
+   "created_at": "2016-10-19T20:25:04Z",
+   "updated_at": "2016-11-08T16:41:26Z",
+   "links": {
+      "self": {
+         "href": "https://api.example.org/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b"
+      },
+      "spaces": {
+         "href": "https://api.example.org/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b/relationships/spaces"
+      },
+      "organizations": {
+         "href": "https://api.example.org/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b/relationships/organizations"
+      }
+   }
+}`

--- a/routes_test.go
+++ b/routes_test.go
@@ -9,8 +9,8 @@ import (
 func TestListRoutes(t *testing.T) {
 	Convey("List Routes", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/routes", listRoutesPayloadPage1, "", 200, ""},
-			{"GET", "/v2/routes_page_2", listRoutesPayloadPage2, "", 200, ""},
+			{"GET", "/v2/routes", listRoutesPayloadPage1, "", 200, "", nil},
+			{"GET", "/v2/routes_page_2", listRoutesPayloadPage2, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()

--- a/secgroups_test.go
+++ b/secgroups_test.go
@@ -9,9 +9,9 @@ import (
 func TestListSecGroups(t *testing.T) {
 	Convey("List SecGroups", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/security_groups", listSecGroupsPayload, "", 200, "inline-relations-depth=1"},
-			{"GET", "/v2/security_groupsPage2", listSecGroupsPayloadPage2, "", 200, ""},
-			{"GET", "/v2/security_groups/af15c29a-6bde-4a9b-8cdf-43aa0d4b7e3c/spaces", emptyResources, "", 200, ""},
+			{"GET", "/v2/security_groups", listSecGroupsPayload, "", 200, "inline-relations-depth=1", nil},
+			{"GET", "/v2/security_groupsPage2", listSecGroupsPayloadPage2, "", 200, "", nil},
+			{"GET", "/v2/security_groups/af15c29a-6bde-4a9b-8cdf-43aa0d4b7e3c/spaces", emptyResources, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -60,8 +60,8 @@ func TestListSecGroups(t *testing.T) {
 func TestSecGroupListSpaceResources(t *testing.T) {
 	Convey("List Space Resources", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/security_groups/123/spaces", listSpacesPayload, "", 200, ""},
-			{"GET", "/v2/spacesPage2", listSpacesPayloadPage2, "", 200, ""},
+			{"GET", "/v2/security_groups/123/spaces", listSpacesPayload, "", 200, "", nil},
+			{"GET", "/v2/spacesPage2", listSpacesPayloadPage2, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()

--- a/service_bindings_test.go
+++ b/service_bindings_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestListServiceBindings(t *testing.T) {
 	Convey("List Service Bindings", t, func() {
-		setup(MockRoute{"GET", "/v2/service_bindings", listServiceBindingsPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/service_bindings", listServiceBindingsPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,

--- a/service_instances_test.go
+++ b/service_instances_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestListServicesInstances(t *testing.T) {
 	Convey("List Service Instances", t, func() {
-		setup(MockRoute{"GET", "/v2/service_instances", listServiceInstancePayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/service_instances", listServiceInstancePayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -28,7 +28,7 @@ func TestListServicesInstances(t *testing.T) {
 
 func TestServiceInstanceByGuid(t *testing.T) {
 	Convey("Service instance by Guid", t, func() {
-		setup(MockRoute{"GET", "/v2/service_instances/8423ca96-90ad-411f-b77a-0907844949fc", serviceInstancePayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/service_instances/8423ca96-90ad-411f-b77a-0907844949fc", serviceInstancePayload, "", 200, "", nil}, t)
 		defer teardown()
 
 		c := &Config{

--- a/service_plans_test.go
+++ b/service_plans_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestListServicePlans(t *testing.T) {
 	Convey("List Service Plans", t, func() {
-		setup(MockRoute{"GET", "/v2/service_plans", listServicePlansPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/service_plans", listServicePlansPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,

--- a/services_test.go
+++ b/services_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestListServices(t *testing.T) {
 	Convey("List Services", t, func() {
-		setup(MockRoute{"GET", "/v2/services", listServicePayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/services", listServicePayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,

--- a/space_quotas_test.go
+++ b/space_quotas_test.go
@@ -9,8 +9,8 @@ import (
 func TestListSpaceQuotas(t *testing.T) {
 	Convey("List Space Quotas", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/space_quota_definitions", listSpaceQuotasPayloadPage1, "", 200, ""},
-			{"GET", "/v2/space_quota_definitions_page_2", listSpaceQuotasPayloadPage2, "", 200, ""},
+			{"GET", "/v2/space_quota_definitions", listSpaceQuotasPayloadPage1, "", 200, "", nil},
+			{"GET", "/v2/space_quota_definitions_page_2", listSpaceQuotasPayloadPage2, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -41,7 +41,7 @@ func TestListSpaceQuotas(t *testing.T) {
 
 func TestGetSpaceQuotaByName(t *testing.T) {
 	Convey("Get Space Quota By Name", t, func() {
-		setup(MockRoute{"GET", "/v2/space_quota_definitions", listSpaceQuotasPayloadPage2, "", 200, "q=name:test-2"}, t)
+		setup(MockRoute{"GET", "/v2/space_quota_definitions", listSpaceQuotasPayloadPage2, "", 200, "q=name:test-2", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,

--- a/spaces_test.go
+++ b/spaces_test.go
@@ -9,8 +9,8 @@ import (
 func TestListSpaces(t *testing.T) {
 	Convey("List Space", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/spaces", listSpacesPayload, "", 200, ""},
-			{"GET", "/v2/spacesPage2", listSpacesPayloadPage2, "", 200, ""},
+			{"GET", "/v2/spaces", listSpacesPayload, "", 200, "", nil},
+			{"GET", "/v2/spacesPage2", listSpacesPayloadPage2, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -42,7 +42,7 @@ func TestListSpaces(t *testing.T) {
 
 func TestCreateSpace(t *testing.T) {
 	Convey("Create Space", t, func() {
-		setup(MockRoute{"POST", "/v2/spaces", spacePayload, "", 201, ""}, t)
+		setup(MockRoute{"POST", "/v2/spaces", spacePayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -63,7 +63,7 @@ func TestCreateSpace(t *testing.T) {
 
 func TestSpaceOrg(t *testing.T) {
 	Convey("Find space org", t, func() {
-		setup(MockRoute{"GET", "/v2/org/foobar", orgPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/org/foobar", orgPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -88,7 +88,7 @@ func TestSpaceOrg(t *testing.T) {
 
 func TestSpaceQuota(t *testing.T) {
 	Convey("Get space quota", t, func() {
-		setup(MockRoute{"GET", "/v2/space_quota_definitions/9ffd7c5c-d83c-4786-b399-b7bd54883977", spaceQuotaPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/space_quota_definitions/9ffd7c5c-d83c-4786-b399-b7bd54883977", spaceQuotaPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -121,7 +121,7 @@ func TestSpaceQuota(t *testing.T) {
 
 func TestSpaceSummary(t *testing.T) {
 	Convey("Get space summary", t, func() {
-		setup(MockRoute{"GET", "/v2/spaces/494d8b64-8181-4183-a6d3-6279db8fec6e/summary", spaceSummaryPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/spaces/494d8b64-8181-4183-a6d3-6279db8fec6e/summary", spaceSummaryPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -161,7 +161,7 @@ func TestSpaceSummary(t *testing.T) {
 
 func TestSpaceRoles(t *testing.T) {
 	Convey("Get space roles", t, func() {
-		setup(MockRoute{"GET", "/v2/spaces/494d8b64-8181-4183-a6d3-6279db8fec6e/user_roles", spaceRolesPayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/spaces/494d8b64-8181-4183-a6d3-6279db8fec6e/user_roles", spaceRolesPayload, "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -197,7 +197,7 @@ func TestSpaceRoles(t *testing.T) {
 
 func TestAssociateSpaceAuditorByUsername(t *testing.T) {
 	Convey("Associate auditor by username", t, func() {
-		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", associateSpaceAuditorPayload, "", 201, ""}, t)
+		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", associateSpaceAuditorPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -219,7 +219,7 @@ func TestAssociateSpaceAuditorByUsername(t *testing.T) {
 
 func TestAssociateSpaceDeveloperByUsername(t *testing.T) {
 	Convey("Associate developer by username", t, func() {
-		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/developers", associateSpaceDeveloperPayload, "", 201, ""}, t)
+		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/developers", associateSpaceDeveloperPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -241,7 +241,7 @@ func TestAssociateSpaceDeveloperByUsername(t *testing.T) {
 
 func TestRemoveSpaceDeveloperByUsername(t *testing.T) {
 	Convey("Remove developer by username", t, func() {
-		setup(MockRoute{"DELETE", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/developers", "", "", 204, ""}, t)
+		setup(MockRoute{"DELETE", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/developers", "", "", 204, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -261,7 +261,7 @@ func TestRemoveSpaceDeveloperByUsername(t *testing.T) {
 }
 func TestRemoveSpaceAuditorByUsername(t *testing.T) {
 	Convey("Remove auditor by username", t, func() {
-		setup(MockRoute{"DELETE", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", "", "", 204, ""}, t)
+		setup(MockRoute{"DELETE", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", "", "", 204, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,

--- a/stacks_test.go
+++ b/stacks_test.go
@@ -9,8 +9,8 @@ import (
 func TestListStacks(t *testing.T) {
 	Convey("List Stacks", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/stacks", listStacksPayloadPage1, "", 200, ""},
-			{"GET", "/v2/stacks_page_2", listStacksPayloadPage2, "", 200, ""},
+			{"GET", "/v2/stacks", listStacksPayloadPage1, "", 200, "", nil},
+			{"GET", "/v2/stacks_page_2", listStacksPayloadPage2, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -11,7 +11,7 @@ import (
 func TestListTasks(t *testing.T) {
 	Convey("List Tasks", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v3/tasks", listTasksPayload, "", 200, ""},
+			{"GET", "/v3/tasks", listTasksPayload, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -45,7 +45,7 @@ func TestListTasks(t *testing.T) {
 func TestListTasksByQuery(t *testing.T) {
 	Convey("List Tasks", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v3/tasks", listTasksPayload, "", 200, "names=my-fancy-name&page=1"},
+			{"GET", "/v3/tasks", listTasksPayload, "", 200, "names=my-fancy-name&page=1", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -83,7 +83,7 @@ func TestListTasksByQuery(t *testing.T) {
 func TestCreateTask(t *testing.T) {
 	Convey("Create Task", t, func() {
 		mocks := []MockRoute{
-			{"POST", "/v3/apps/740ebd2b-162b-469a-bd72-3edb96fabd9a/tasks", createTaskPayload, "", 201, ""},
+			{"POST", "/v3/apps/740ebd2b-162b-469a-bd72-3edb96fabd9a/tasks", createTaskPayload, "", 201, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -115,7 +115,7 @@ func TestCreateTask(t *testing.T) {
 func TestTerminateTask(t *testing.T) {
 	Convey("Terminate Task", t, func() {
 		mocks := []MockRoute{
-			{"PUT", "/v3/tasks/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/cancel", "", "", 202, ""},
+			{"PUT", "/v3/tasks/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/cancel", "", "", 202, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -134,7 +134,7 @@ func TestTerminateTask(t *testing.T) {
 func TestGetTask(t *testing.T) {
 	Convey("Create Task", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v3/tasks/740ebd2b-162b-469a-bd72-3edb96fabd9a", createTaskPayload, "", 200, ""},
+			{"GET", "/v3/tasks/740ebd2b-162b-469a-bd72-3edb96fabd9a", createTaskPayload, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -159,7 +159,7 @@ func TestGetTask(t *testing.T) {
 func TestTasksByApp(t *testing.T) {
 	Convey("List Tasks by App", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v3/apps/ccc25a0f-c8f4-4b39-9f1b-de9f328d0ee5/tasks", listTasksPayload, "", 200, ""},
+			{"GET", "/v3/apps/ccc25a0f-c8f4-4b39-9f1b-de9f328d0ee5/tasks", listTasksPayload, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -194,7 +194,7 @@ func TestTasksByApp(t *testing.T) {
 func TestTasksByAppByQuery(t *testing.T) {
 	Convey("List Tasks by App", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v3/apps/ccc25a0f-c8f4-4b39-9f1b-de9f328d0ee5/tasks", listTasksPayload, "", 200, "names=my-fancy-name&page=1"},
+			{"GET", "/v3/apps/ccc25a0f-c8f4-4b39-9f1b-de9f328d0ee5/tasks", listTasksPayload, "", 200, "names=my-fancy-name&page=1", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()

--- a/user_provided_service_instances_test.go
+++ b/user_provided_service_instances_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestUserProvidedServiceInstanceByGuid(t *testing.T) {
 	Convey("Service instance by Guid", t, func() {
-		setup(MockRoute{"GET", "/v2/user_provided_service_instances/e9358711-0ad9-4f2a-b3dc-289d47c17c87", userProvidedServiceInstancePayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/user_provided_service_instances/e9358711-0ad9-4f2a-b3dc-289d47c17c87", userProvidedServiceInstancePayload, "", 200, "", nil}, t)
 		defer teardown()
 
 		c := &Config{
@@ -39,7 +39,7 @@ func TestUserProvidedServiceInstanceByGuid(t *testing.T) {
 
 func TestListUserProvidedServiceInstances(t *testing.T) {
 	Convey("List Service Instances", t, func() {
-		setup(MockRoute{"GET", "/v2/user_provided_service_instances", listUserProvidedServiceInstancePayload, "", 200, ""}, t)
+		setup(MockRoute{"GET", "/v2/user_provided_service_instances", listUserProvidedServiceInstancePayload, "", 200, "", nil}, t)
 		defer teardown()
 
 		c := &Config{

--- a/users_test.go
+++ b/users_test.go
@@ -9,8 +9,8 @@ import (
 func TestListUsers(t *testing.T) {
 	Convey("List Users", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/users", listUsersPayload, "", 200, ""},
-			{"GET", "/v2/usersPage2", listUsersPayloadPage2, "", 200, ""},
+			{"GET", "/v2/users", listUsersPayload, "", 200, "", nil},
+			{"GET", "/v2/usersPage2", listUsersPayloadPage2, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -39,7 +39,7 @@ func TestListUsers(t *testing.T) {
 func TestListUserSpaces(t *testing.T) {
 	Convey("List User Spaces", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/users/cadd6389-fcf6-4928-84f0-6153556bf693/spaces", listUserSpacesPayload, "", 200, ""},
+			{"GET", "/v2/users/cadd6389-fcf6-4928-84f0-6153556bf693/spaces", listUserSpacesPayload, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -63,7 +63,7 @@ func TestListUserSpaces(t *testing.T) {
 func TestListUserManagedSpaces(t *testing.T) {
 	Convey("List User Audited Spaces", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/users/cadd6389-fcf6-4928-84f0-6153556bf693/managed_spaces", listUserSpacesPayload, "", 200, ""},
+			{"GET", "/v2/users/cadd6389-fcf6-4928-84f0-6153556bf693/managed_spaces", listUserSpacesPayload, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -87,7 +87,7 @@ func TestListUserManagedSpaces(t *testing.T) {
 func TestListUserAuditedSpaces(t *testing.T) {
 	Convey("List User Managed Spaces", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v2/users/cadd6389-fcf6-4928-84f0-6153556bf693/audited_spaces", listUserSpacesPayload, "", 200, ""},
+			{"GET", "/v2/users/cadd6389-fcf6-4928-84f0-6153556bf693/audited_spaces", listUserSpacesPayload, "", 200, "", nil},
 		}
 		setupMultiple(mocks, t)
 		defer teardown()
@@ -125,7 +125,7 @@ func TestGetUserByUsername(t *testing.T) {
 
 func TestCreateUser(t *testing.T) {
 	Convey("Create user", t, func() {
-		setup(MockRoute{"POST", "/v2/users", createUserPayload, "", 201, ""}, t)
+		setup(MockRoute{"POST", "/v2/users", createUserPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -142,7 +142,7 @@ func TestCreateUser(t *testing.T) {
 
 func TestDeleteUser(t *testing.T) {
 	Convey("Delete user", t, func() {
-		setup(MockRoute{"DELETE", "/v2/users/guid-cb24b36d-4656-468e-a50d-b53113ac6177", "", "", 204, ""}, t)
+		setup(MockRoute{"DELETE", "/v2/users/guid-cb24b36d-4656-468e-a50d-b53113ac6177", "", "", 204, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,


### PR DESCRIPTION
Support of PCF Isolation Segments. Added support for testing POST body in the 
test infrastructure (as *string which can be switched later to a more complex 
structure if needed). For that it was required to add the new struct field as nil in 
the existing tests.

Daniel