### PR TITLE
Fix the DoRequest call on faulty URLs

### DIFF
--- a/client.go
+++ b/client.go
@@ -267,6 +267,9 @@ func (c *Client) DoRequest(r *request) (*http.Response, error) {
 	}
 
 	resp, err := c.config.HttpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
 
 	if resp.StatusCode >= http.StatusBadRequest {
 		cfErr := &CloudFoundryErrors{}
@@ -276,7 +279,7 @@ func (c *Client) DoRequest(r *request) (*http.Response, error) {
 		return nil, cfErr
 	}
 
-	return resp, err
+	return resp, nil
 }
 
 // toHTTP converts the request to an HTTP request

--- a/client_test.go
+++ b/client_test.go
@@ -40,6 +40,26 @@ func TestMakeRequest(t *testing.T) {
 	})
 }
 
+func TestMakeRequestFailure(t *testing.T) {
+	Convey("Test making request b", t, func() {
+		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, "", 200, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress:        server.URL,
+			Username:          "foo",
+			Password:          "bar",
+			SkipSslValidation: true,
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+		req := client.NewRequest("GET", "/v2/organizations")
+		req.url = "%gh&%ij"
+		resp, err := client.DoRequest(req)
+		So(resp, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+	})
+}
+
 func TestMakeRequestWithTimeout(t *testing.T) {
 	Convey("Test making request b", t, func() {
 		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, "", 200, "", nil}, t)


### PR DESCRIPTION
## What

At the moment, we're relying on the `c.config.HttpClient.Do` to always
return a response. It's very odd approach, presuming it will always
success. If it does manage to fail, we'd like to be able to continue
without causing the panic.

With the following change, we're going to gracefully fail, before
continuing with our if statement.

At the end, when all the errors have managed to be omitted, we can
safely return a `nil`.

## How to review

- Lurking over the code
- Running `ginkgo`/`go test`