### PR TITLE
Add service plan visibilities functionality

### DIFF
--- a/payloads_test.go
+++ b/payloads_test.go
@@ -1467,6 +1467,58 @@ const listServicePayload = `{
    ]
 }`
 
+const listServicePlanVisibilitiesPayload = `{
+  "total_results": 4,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "d1b5ea55-f354-4f43-b52e-53045747adb9",
+        "url": "/v2/service_plan_visibilities/d1b5ea55-f354-4f43-b52e-53045747adb9",
+        "created_at": "2016-06-08T16:41:31Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "service_plan_guid": "62cb572c-e9ca-4c9f-b822-8292db1d9a96",
+        "organization_guid": "81df84f3-8ce0-4c92-990a-3760b6ff66bd",
+        "service_plan_url": "/v2/service_plans/62cb572c-e9ca-4c9f-b822-8292db1d9a96",
+        "organization_url": "/v2/organizations/81df84f3-8ce0-4c92-990a-3760b6ff66bd"
+      }
+    },
+    {
+      "metadata": {
+        "guid": "332331a3-7b6c-413b-a2e4-edf90ac47fa9",
+        "url": "/v2/service_plan_visibilities/332331a3-7b6c-413b-a2e4-edf90ac47fa9",
+        "created_at": "2016-06-08T16:41:31Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "service_plan_guid": "c505f2ec-81ed-4091-b194-b8e905f32b24",
+        "organization_guid": "99b61b74-09d6-47db-9568-a835e42d0a1d",
+        "service_plan_url": "/v2/service_plans/c505f2ec-81ed-4091-b194-b8e905f32b24",
+        "organization_url": "/v2/organizations/99b61b74-09d6-47db-9568-a835e42d0a1d"
+      }
+    }
+  ]
+}`
+
+const postServicePlanVisibilityPayload = `{
+  "metadata": {
+    "guid": "f740b01a-4afe-4435-aedd-0a8308a7e7d6",
+    "url": "/v2/service_plan_visibilities/f740b01a-4afe-4435-aedd-0a8308a7e7d6",
+    "created_at": "2016-06-08T16:41:31Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "service_plan_guid": "ab5780a9-ac8e-4412-9496-4512e865011a",
+    "organization_guid": "55d0ff39-dac9-431f-ba6d-83f37381f1c3",
+    "service_plan_url": "/v2/service_plans/ab5780a9-ac8e-4412-9496-4512e865011a",
+    "organization_url": "/v2/organizations/55d0ff39-dac9-431f-ba6d-83f37381f1c3"
+  }
+}`
+
 const listAppsCreatedEventPayload = `{
    "total_results": 3,
    "total_pages": 2,
@@ -2468,4 +2520,3 @@ const getServiceKeyPayload = `{
     }
   ]
 }`
-

--- a/service_plan_visibilities.go
+++ b/service_plan_visibilities.go
@@ -1,0 +1,100 @@
+package cfclient
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+type ServicePlanVisibilitiesResponse struct {
+	Count     int                             `json:"total_results"`
+	Pages     int                             `json:"total_pages"`
+	NextUrl   string                          `json:"next_url"`
+	Resources []ServicePlanVisibilityResource `json:"resources"`
+}
+
+type ServicePlanVisibilityResource struct {
+	Meta   Meta                  `json:"metadata"`
+	Entity ServicePlanVisibility `json:"entity"`
+}
+
+type ServicePlanVisibility struct {
+	Guid             string `json:"guid"`
+	ServicePlanGuid  string `json:"service_plan_guid"`
+	OrganizationGuid string `json:"organization_guid"`
+	ServicePlanUrl   string `json:"service_plan_url"`
+	OrganizationUrl  string `json:"organization_url"`
+	c                *Client
+}
+
+func (c *Client) ListServicePlanVisibilitiesByQuery(query url.Values) ([]ServicePlanVisibility, error) {
+	var servicePlanVisibilities []ServicePlanVisibility
+	requestUrl := "/v2/service_plan_visibilities?" + query.Encode()
+	for {
+		var servicePlanVisibilitiesResp ServicePlanVisibilitiesResponse
+		r := c.NewRequest("GET", requestUrl)
+		resp, err := c.DoRequest(r)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error requesting service plan visibilities")
+		}
+		resBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error reading service plan visibilities request:")
+		}
+
+		err = json.Unmarshal(resBody, &servicePlanVisibilitiesResp)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error unmarshaling service plan visibilities")
+		}
+		for _, servicePlanVisibility := range servicePlanVisibilitiesResp.Resources {
+			servicePlanVisibility.Entity.Guid = servicePlanVisibility.Meta.Guid
+			servicePlanVisibility.Entity.c = c
+			servicePlanVisibilities = append(servicePlanVisibilities, servicePlanVisibility.Entity)
+		}
+		requestUrl = servicePlanVisibilitiesResp.NextUrl
+		if requestUrl == "" {
+			break
+		}
+	}
+	return servicePlanVisibilities, nil
+}
+
+func (c *Client) ListServicePlanVisibilities() ([]ServicePlanVisibility, error) {
+	return c.ListServicePlanVisibilitiesByQuery(nil)
+}
+
+func (c *Client) CreateServicePlanVisibility(servicePlanGuid string, organizationGuid string) (*ServicePlanVisibility, error) {
+	req := c.NewRequest("POST", "/v2/service_plan_visibilities")
+	req.obj = map[string]interface{}{
+		"service_plan_guid": servicePlanGuid,
+		"organization_guid": organizationGuid,
+	}
+	resp, err := c.DoRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return nil, errors.Wrapf(err, "Error creating service plan visibility, response code: %d", resp.StatusCode)
+	}
+	return respBodyToServicePlanVisibility(resp.Body, c)
+}
+
+func respBodyToServicePlanVisibility(body io.ReadCloser, c *Client) (*ServicePlanVisibility, error) {
+	bodyRaw, err := ioutil.ReadAll(body)
+	if err != nil {
+		return nil, err
+	}
+	servicePlanVisibilityRes := ServicePlanVisibilityResource{}
+	err = json.Unmarshal([]byte(bodyRaw), &servicePlanVisibilityRes)
+	if err != nil {
+		return nil, err
+	}
+	servicePlanVisibility := servicePlanVisibilityRes.Entity
+	servicePlanVisibility.Guid = servicePlanVisibilityRes.Meta.Guid
+	servicePlanVisibility.c = c
+	return &servicePlanVisibility, nil
+}

--- a/service_plan_visibilities_test.go
+++ b/service_plan_visibilities_test.go
@@ -1,0 +1,52 @@
+package cfclient
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestListServicePlanVisibilities(t *testing.T) {
+	Convey("List service plan visibilities", t, func() {
+		setup(MockRoute{"GET", "/v2/service_plan_visibilities", listServicePlanVisibilitiesPayload, "", 200, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		servicePlanVisibilities, err := client.ListServicePlanVisibilities()
+		So(err, ShouldBeNil)
+
+		So(len(servicePlanVisibilities), ShouldEqual, 2)
+		So(servicePlanVisibilities[0].Guid, ShouldEqual, "d1b5ea55-f354-4f43-b52e-53045747adb9")
+		So(servicePlanVisibilities[0].ServicePlanGuid, ShouldEqual, "62cb572c-e9ca-4c9f-b822-8292db1d9a96")
+		So(servicePlanVisibilities[0].OrganizationGuid, ShouldEqual, "81df84f3-8ce0-4c92-990a-3760b6ff66bd")
+		So(servicePlanVisibilities[0].ServicePlanUrl, ShouldEqual, "/v2/service_plans/62cb572c-e9ca-4c9f-b822-8292db1d9a96")
+		So(servicePlanVisibilities[0].OrganizationUrl, ShouldEqual, "/v2/organizations/81df84f3-8ce0-4c92-990a-3760b6ff66bd")
+	})
+}
+
+func TestCreateServicePlanVisibility(t *testing.T) {
+	Convey("Create service plan visibility", t, func() {
+		setup(MockRoute{"POST", "/v2/service_plan_visibilities", postServicePlanVisibilityPayload, "", 201, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		servicePlanVisibility, err := client.CreateServicePlanVisibility("ab5780a9-ac8e-4412-9496-4512e865011a", "55d0ff39-dac9-431f-ba6d-83f37381f1c3")
+		So(err, ShouldBeNil)
+
+		So(servicePlanVisibility.Guid, ShouldEqual, "f740b01a-4afe-4435-aedd-0a8308a7e7d6")
+		So(servicePlanVisibility.ServicePlanGuid, ShouldEqual, "ab5780a9-ac8e-4412-9496-4512e865011a")
+		So(servicePlanVisibility.OrganizationGuid, ShouldEqual, "55d0ff39-dac9-431f-ba6d-83f37381f1c3")
+		So(servicePlanVisibility.ServicePlanUrl, ShouldEqual, "/v2/service_plans/ab5780a9-ac8e-4412-9496-4512e865011a")
+		So(servicePlanVisibility.OrganizationUrl, ShouldEqual, "/v2/organizations/55d0ff39-dac9-431f-ba6d-83f37381f1c3")
+	})
+}


### PR DESCRIPTION
Adds [list service plan visibilities](https://apidocs.cloudfoundry.org/258/service_plan_visibilities/list_all_service_plan_visibilities.html) and [create service plan visibility](https://apidocs.cloudfoundry.org/258/service_plan_visibilities/creating_a_service_plan_visibility.html) functionality.