### PR TITLE
Fix error handling for requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -272,8 +272,8 @@ func (c *Client) DoRequest(r *request) (*http.Response, error) {
 	}
 
 	if resp.StatusCode >= http.StatusBadRequest {
-		cfErr := &CloudFoundryErrors{}
-		if err := decodeBody(resp, cfErr); err != nil {
+		var cfErr CloudFoundryError
+		if err := decodeBody(resp, &cfErr); err != nil {
 			return resp, errors.Wrap(err, "Unable to decode body")
 		}
 		return nil, cfErr


### PR DESCRIPTION
Unmarshalling into `CloudFoundryErrors` didn't work for me because CF returned only one error.