### PR TITLE
Fixed errors with get private and shared domain calls

### DIFF
--- a/cf_test.go
+++ b/cf_test.go
@@ -84,10 +84,10 @@ func setupMultiple(mockEndpoints []MockRoute, t *testing.T) {
 		queryString := mock.QueryString
 		postFormBody := mock.PostForm
 		if method == "GET" {
-			r.Get(endpoint, func(req *http.Request) string {
+			r.Get(endpoint, func(req *http.Request) (int, string) {
 				testUserAgent(req.Header.Get("User-Agent"), userAgent, t)
 				testQueryString(req.URL.RawQuery, queryString, t)
-				return output
+				return status, output
 			})
 		} else if method == "POST" {
 			r.Post(endpoint, func(req *http.Request) (int, string) {

--- a/domains.go
+++ b/domains.go
@@ -129,10 +129,10 @@ func (c *Client) GetDomainByName(name string) (Domain, error) {
 	q.Set("q", "name:"+name)
 	domains, err := c.ListDomainsByQuery(q)
 	if err != nil {
-		return Domain{}, nil
+		return Domain{}, errors.Wrapf(err, "Error during domain lookup %s", name)
 	}
 	if len(domains) == 0 {
-		return Domain{}, errors.Wrapf(err, "Unable to find domain %s", name)
+		return Domain{}, errors.New(fmt.Sprintf("Unable to find domain %s", name))
 	}
 	return domains[0], nil
 }
@@ -142,10 +142,10 @@ func (c *Client) GetSharedDomainByName(name string) (SharedDomain, error) {
 	q.Set("q", "name:"+name)
 	domains, err := c.ListSharedDomainsByQuery(q)
 	if err != nil {
-		return SharedDomain{}, nil
+		return SharedDomain{}, errors.Wrapf(err, "Error during shared domain lookup %s", name)
 	}
 	if len(domains) == 0 {
-		return SharedDomain{}, errors.Wrapf(err, "Unable to find shared domain %s", name)
+		return SharedDomain{}, errors.New(fmt.Sprintf("Unable to find shared domain %s", name))
 	}
 	return domains[0], nil
 }

--- a/domains_test.go
+++ b/domains_test.go
@@ -51,6 +51,96 @@ func TestListSharedDomains(t *testing.T) {
 	})
 }
 
+func TestGetDomainByName(t *testing.T) {
+	Convey("Get domain by name", t, func() {
+		setup(MockRoute{"GET", "/v2/private_domains", listDomainsPayload, "", 200, "q=name:vcap.me", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		domain, err := client.GetDomainByName("vcap.me")
+		So(err, ShouldBeNil)
+
+		So(domain.Guid, ShouldEqual, "b2a35f0c-d5ad-4a59-bea7-461711d96b0d")
+		So(domain.Name, ShouldEqual, "vcap.me")
+	})
+	Convey("Get domain by name with an endpoint that returns a 404", t, func() {
+		setup(MockRoute{"GET", "/v2/private_domains", listDomainsEmptyResponse, "", 404, "q=name:vcap.me", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		_, listErr := client.GetDomainByName("vcap.me")
+		So(listErr, ShouldNotBeNil)
+	})
+	Convey("Get domain by name for a non-existing domain", t, func() {
+		setup(MockRoute{"GET", "/v2/private_domains", listDomainsEmptyResponse, "", 200, "q=name:idontexist", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		_, listErr := client.GetDomainByName("idontexist")
+		So(listErr, ShouldNotBeNil)
+	})
+}
+
+func TestGetSharedDomainByName(t *testing.T) {
+	Convey("Get shared domain by name", t, func() {
+		setup(MockRoute{"GET", "/v2/shared_domains", listSharedDomainsPayload, "", 200, "q=name:domain-49.example.com", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		domain, err := client.GetSharedDomainByName("domain-49.example.com")
+		So(err, ShouldBeNil)
+
+		So(domain.Guid, ShouldEqual, "91977695-8ad9-40db-858f-4df782603ec3")
+		So(domain.Name, ShouldEqual, "domain-49.example.com")
+	})
+	Convey("Get shared domain by name with an endpoint that returns a 404", t, func() {
+		setup(MockRoute{"GET", "/v2/shared_domains", listDomainsEmptyResponse, "", 404, "q=name:domain-49.example.com", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		_, listErr := client.GetSharedDomainByName("domain-49.example.com")
+		So(listErr, ShouldNotBeNil)
+	})
+	Convey("Get shared domain by name for a non-existing domain", t, func() {
+		setup(MockRoute{"GET", "/v2/shared_domains", listDomainsEmptyResponse, "", 200, "q=name:idontexist", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		_, listErr := client.GetSharedDomainByName("idontexist")
+		So(listErr, ShouldNotBeNil)
+	})
+}
+
 func TestCreateDomain(t *testing.T) {
 	Convey("Create domain", t, func() {
 		setup(MockRoute{"POST", "/v2/private_domains", postDomainPayload, "", 201, "", nil}, t)

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -2119,6 +2119,15 @@ const listSharedDomainsPayload = `{
     }
   ]
 }`
+
+const listDomainsEmptyResponse = `{
+  "total_results": 0,
+  "total_pages": 0,
+  "prev_url": null,
+  "next_url": null,
+  "resources": []
+}`
+
 const postDomainPayload = `{
   "metadata": {
     "guid": "b98aeca1-22b9-49f9-8428-3ace9ea2ba11",


### PR DESCRIPTION
Found an issue with the way we were handling errors in the private_domains/shared_domains lookup calls.

Signed-off-by: Felix Reyn <freyn@pivotal.io>