### PR TITLE
Use consistent names for get by guid methods.

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -301,7 +301,7 @@ func (c *Client) KillAppInstance(guid string, index string) error {
 	return nil
 }
 
-func (c *Client) AppByGuid(guid string) (App, error) {
+func (c *Client) GetAppByGuid(guid string) (App, error) {
 	var appResource AppResource
 	r := c.NewRequest("GET", "/v2/apps/"+guid+"?inline-relations-depth=2")
 	resp, err := c.DoRequest(r)
@@ -323,6 +323,10 @@ func (c *Client) AppByGuid(guid string) (App, error) {
 	appResource.Entity.SpaceData.Entity.OrgData.Entity.Guid = appResource.Entity.SpaceData.Entity.OrgData.Meta.Guid
 	appResource.Entity.c = c
 	return appResource.Entity, nil
+}
+
+func (c *Client) AppByGuid(guid string) (App, error) {
+	return c.GetAppByGuid(guid)
 }
 
 //AppByName takes an appName, and GUIDs for a space and org, and performs

--- a/apps_test.go
+++ b/apps_test.go
@@ -72,7 +72,7 @@ func TestAppByGuid(t *testing.T) {
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 
-		app, err := client.AppByGuid("9902530c-c634-4864-a189-71d763cb12e2")
+		app, err := client.GetAppByGuid("9902530c-c634-4864-a189-71d763cb12e2")
 		So(err, ShouldBeNil)
 
 		So(app.Guid, ShouldEqual, "9902530c-c634-4864-a189-71d763cb12e2")
@@ -89,7 +89,7 @@ func TestAppByGuid(t *testing.T) {
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 
-		app, err := client.AppByGuid("9902530c-c634-4864-a189-71d763cb12e2")
+		app, err := client.GetAppByGuid("9902530c-c634-4864-a189-71d763cb12e2")
 		So(err, ShouldBeNil)
 
 		So(app.Environment["string"], ShouldEqual, "string")

--- a/service_bindings.go
+++ b/service_bindings.go
@@ -63,7 +63,7 @@ func (c *Client) ListServiceBindings() ([]ServiceBinding, error) {
 	return c.ListServiceBindingsByQuery(nil)
 }
 
-func (c *Client) ServiceBindingByGuid(guid string) (ServiceBinding, error) {
+func (c *Client) GetServiceBindingByGuid(guid string) (ServiceBinding, error) {
 	var serviceBinding ServiceBindingResource
 	r := c.NewRequest("GET", "/v2/service_bindings/"+url.QueryEscape(guid))
 	resp, err := c.DoRequest(r)
@@ -82,4 +82,8 @@ func (c *Client) ServiceBindingByGuid(guid string) (ServiceBinding, error) {
 	serviceBinding.Entity.Guid = serviceBinding.Meta.Guid
 	serviceBinding.Entity.c = c
 	return serviceBinding.Entity, nil
+}
+
+func (c *Client) ServiceBindingByGuid(guid string) (ServiceBinding, error) {
+	return c.GetServiceBindingByGuid(guid)
 }

--- a/service_bindings_test.go
+++ b/service_bindings_test.go
@@ -48,7 +48,7 @@ func TestServiceBindingByGuid(t *testing.T) {
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 
-		serviceBinding, err := client.ServiceBindingByGuid("foo-bar-baz")
+		serviceBinding, err := client.GetServiceBindingByGuid("foo-bar-baz")
 		So(err, ShouldBeNil)
 
 		So(serviceBinding.Guid, ShouldEqual, "foo-bar-baz")

--- a/service_instances.go
+++ b/service_instances.go
@@ -86,7 +86,7 @@ func (c *Client) ListServiceInstances() ([]ServiceInstance, error) {
 	return c.ListServiceInstancesByQuery(nil)
 }
 
-func (c *Client) ServiceInstanceByGuid(guid string) (ServiceInstance, error) {
+func (c *Client) GetServiceInstanceByGuid(guid string) (ServiceInstance, error) {
 	var sir ServiceInstanceResource
 	req := c.NewRequest("GET", "/v2/service_instances/"+guid)
 	res, err := c.DoRequest(req)
@@ -105,4 +105,8 @@ func (c *Client) ServiceInstanceByGuid(guid string) (ServiceInstance, error) {
 	sir.Entity.Guid = sir.Meta.Guid
 	sir.Entity.c = c
 	return sir.Entity, nil
+}
+
+func (c *Client) ServiceInstanceByGuid(guid string) (ServiceInstance, error) {
+	return c.GetServiceInstanceByGuid(guid)
 }

--- a/service_instances_test.go
+++ b/service_instances_test.go
@@ -38,7 +38,7 @@ func TestServiceInstanceByGuid(t *testing.T) {
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 
-		service, err := client.ServiceInstanceByGuid("8423ca96-90ad-411f-b77a-0907844949fc")
+		service, err := client.GetServiceInstanceByGuid("8423ca96-90ad-411f-b77a-0907844949fc")
 		So(err, ShouldBeNil)
 
 		expected := ServiceInstance{

--- a/tasks.go
+++ b/tasks.go
@@ -179,7 +179,7 @@ func (c *Client) CreateTask(tr TaskRequest) (task Task, err error) {
 }
 
 // TaskByGuid returns a task structure by requesting it with the tasks GUID.
-func (c *Client) TaskByGuid(guid string) (task Task, err error) {
+func (c *Client) GetTaskByGuid(guid string) (task Task, err error) {
 	request := fmt.Sprintf("/v3/tasks/%s", guid)
 	req := c.NewRequest("GET", request)
 
@@ -199,6 +199,10 @@ func (c *Client) TaskByGuid(guid string) (task Task, err error) {
 		return task, errors.Wrap(err, "Error unmarshaling task")
 	}
 	return task, err
+}
+
+func (c *Client) TaskByGuid(guid string) (task Task, err error) {
+	return c.GetTaskByGuid(guid)
 }
 
 // TerminateTask cancels a task identified by its GUID.

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -145,7 +145,7 @@ func TestGetTask(t *testing.T) {
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 
-		task, err := client.TaskByGuid("740ebd2b-162b-469a-bd72-3edb96fabd9a")
+		task, err := client.GetTaskByGuid("740ebd2b-162b-469a-bd72-3edb96fabd9a")
 		So(err, ShouldBeNil)
 
 		So(task.Command, ShouldEqual, "rake db:migrate")

--- a/user_provided_service_instances.go
+++ b/user_provided_service_instances.go
@@ -73,7 +73,7 @@ func (c *Client) ListUserProvidedServiceInstances() ([]UserProvidedServiceInstan
 	return c.ListUserProvidedServiceInstancesByQuery(nil)
 }
 
-func (c *Client) UserProvidedServiceInstanceByGuid(guid string) (UserProvidedServiceInstance, error) {
+func (c *Client) GetUserProvidedServiceInstanceByGuid(guid string) (UserProvidedServiceInstance, error) {
 	var sir UserProvidedServiceInstanceResource
 	req := c.NewRequest("GET", "/v2/user_provided_service_instances/"+guid)
 	res, err := c.DoRequest(req)
@@ -92,4 +92,8 @@ func (c *Client) UserProvidedServiceInstanceByGuid(guid string) (UserProvidedSer
 	sir.Entity.Guid = sir.Meta.Guid
 	sir.Entity.c = c
 	return sir.Entity, nil
+}
+
+func (c *Client) UserProvidedServiceInstanceByGuid(guid string) (UserProvidedServiceInstance, error) {
+	return c.GetUserProvidedServiceInstanceByGuid(guid)
 }

--- a/user_provided_service_instances_test.go
+++ b/user_provided_service_instances_test.go
@@ -19,7 +19,7 @@ func TestUserProvidedServiceInstanceByGuid(t *testing.T) {
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 
-		instance, err := client.UserProvidedServiceInstanceByGuid("e9358711-0ad9-4f2a-b3dc-289d47c17c87")
+		instance, err := client.GetUserProvidedServiceInstanceByGuid("e9358711-0ad9-4f2a-b3dc-289d47c17c87")
 		So(err, ShouldBeNil)
 
 		So(instance.Guid, ShouldEqual, "e9358711-0ad9-4f2a-b3dc-289d47c17c87")


### PR DESCRIPTION
With aliases for backward compatibility.