### PR TITLE
expose /v2/routes/{uuid}/apps endpoint in ListAppsByRoute()

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -175,9 +175,21 @@ func (a *App) Space() (Space, error) {
 }
 
 func (c *Client) ListAppsByQuery(query url.Values) ([]App, error) {
-	var apps []App
+	return c.listApps("/v2/apps?" + query.Encode())
+}
 
-	requestUrl := "/v2/apps?" + query.Encode()
+func (c *Client) ListApps() ([]App, error) {
+	q := url.Values{}
+	q.Set("inline-relations-depth", "2")
+	return c.ListAppsByQuery(q)
+}
+
+func (c *Client) ListAppsByRoute(routeGuid string) ([]App, error) {
+	return c.listApps(fmt.Sprintf("/v2/routes/%s/apps", routeGuid))
+}
+
+func (c *Client) listApps(requestUrl string) ([]App, error) {
+	apps := []App{}
 	for {
 		var appResp AppResponse
 		r := c.NewRequest("GET", requestUrl)
@@ -212,12 +224,6 @@ func (c *Client) ListAppsByQuery(query url.Values) ([]App, error) {
 		}
 	}
 	return apps, nil
-}
-
-func (c *Client) ListApps() ([]App, error) {
-	q := url.Values{}
-	q.Set("inline-relations-depth", "2")
-	return c.ListAppsByQuery(q)
 }
 
 func (c *Client) GetAppInstances(guid string) (map[string]AppInstance, error) {

--- a/apps_test.go
+++ b/apps_test.go
@@ -24,41 +24,66 @@ func TestListApps(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		apps, err := client.ListApps()
+		assertAppList(apps, err)
+	})
+}
+
+func TestListAppsByRoute(t *testing.T) {
+	Convey("List Apps by Route", t, func() {
+		mocks := []MockRoute{
+			{"GET", "/v2/routes/a3fb8d86-4620-4725-b643-0b5122a432e0/apps", listAppsPayload, "Test-golang", 200, "", nil},
+			{"GET", "/v2/appsPage2", listAppsPayloadPage2, "Test-golang", 200, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+			UserAgent:  "Test-golang",
+		}
+		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 
-		So(len(apps), ShouldEqual, 2)
-		So(apps[0].Guid, ShouldEqual, "af15c29a-6bde-4a9b-8cdf-43aa0d4b7e3c")
-		So(apps[0].CreatedAt, ShouldEqual, "2014-10-10T21:03:13+00:00")
-		So(apps[0].UpdatedAt, ShouldEqual, "2014-11-10T14:07:31+00:00")
-		So(apps[0].Name, ShouldEqual, "app-test")
-		So(apps[0].Memory, ShouldEqual, 256)
-		So(apps[0].Instances, ShouldEqual, 1)
-		So(apps[0].DiskQuota, ShouldEqual, 1024)
-		So(apps[0].SpaceGuid, ShouldEqual, "8efd7c5c-d83c-4786-b399-b7bd548839e1")
-		So(apps[0].StackGuid, ShouldEqual, "2c531037-68a2-4e2c-a9e0-71f9d0abf0d4")
-		So(apps[0].State, ShouldEqual, "STARTED")
-		So(apps[0].Command, ShouldEqual, "")
-		So(apps[0].Buildpack, ShouldEqual, "https://github.com/cloudfoundry/buildpack-go.git")
-		So(apps[0].DetectedBuildpack, ShouldEqual, "")
-		So(apps[0].DetectedBuildpackGuid, ShouldEqual, "0d22f6a1-76c5-417f-ac6c-d9d21463ecbc")
-		So(apps[0].HealthCheckHttpEndpoint, ShouldEqual, "")
-		So(apps[0].HealthCheckType, ShouldEqual, "port")
-		So(apps[0].HealthCheckTimeout, ShouldEqual, 0)
-		So(apps[0].Diego, ShouldEqual, true)
-		So(apps[0].EnableSSH, ShouldEqual, true)
-		So(apps[0].DetectedStartCommand, ShouldEqual, "app-launching-service-broker")
-		So(apps[0].DockerImage, ShouldEqual, "")
-		So(apps[0].DockerCredentials["redacted_message"], ShouldEqual, "[PRIVATE DATA HIDDEN]")
-		So(apps[0].Environment["FOOBAR"], ShouldEqual, "QUX")
-		So(apps[0].StagingFailedReason, ShouldEqual, "")
-		So(apps[0].StagingFailedDescription, ShouldEqual, "")
-		So(apps[0].PackageState, ShouldEqual, "PENDING")
-		So(len(apps[0].Ports), ShouldEqual, 1)
-		So(apps[0].Ports[0], ShouldEqual, 8080)
-
-		So(apps[1].Guid, ShouldEqual, "f9ad202b-76dd-44ec-b7c2-fd2417a561e8")
-		So(apps[1].Name, ShouldEqual, "app-test2")
+		apps, err := client.ListAppsByRoute("a3fb8d86-4620-4725-b643-0b5122a432e0")
+		assertAppList(apps, err)
 	})
+}
+
+func assertAppList(apps []App, err error) {
+	So(err, ShouldBeNil)
+
+	So(len(apps), ShouldEqual, 2)
+	So(apps[0].Guid, ShouldEqual, "af15c29a-6bde-4a9b-8cdf-43aa0d4b7e3c")
+	So(apps[0].CreatedAt, ShouldEqual, "2014-10-10T21:03:13+00:00")
+	So(apps[0].UpdatedAt, ShouldEqual, "2014-11-10T14:07:31+00:00")
+	So(apps[0].Name, ShouldEqual, "app-test")
+	So(apps[0].Memory, ShouldEqual, 256)
+	So(apps[0].Instances, ShouldEqual, 1)
+	So(apps[0].DiskQuota, ShouldEqual, 1024)
+	So(apps[0].SpaceGuid, ShouldEqual, "8efd7c5c-d83c-4786-b399-b7bd548839e1")
+	So(apps[0].StackGuid, ShouldEqual, "2c531037-68a2-4e2c-a9e0-71f9d0abf0d4")
+	So(apps[0].State, ShouldEqual, "STARTED")
+	So(apps[0].Command, ShouldEqual, "")
+	So(apps[0].Buildpack, ShouldEqual, "https://github.com/cloudfoundry/buildpack-go.git")
+	So(apps[0].DetectedBuildpack, ShouldEqual, "")
+	So(apps[0].DetectedBuildpackGuid, ShouldEqual, "0d22f6a1-76c5-417f-ac6c-d9d21463ecbc")
+	So(apps[0].HealthCheckHttpEndpoint, ShouldEqual, "")
+	So(apps[0].HealthCheckType, ShouldEqual, "port")
+	So(apps[0].HealthCheckTimeout, ShouldEqual, 0)
+	So(apps[0].Diego, ShouldEqual, true)
+	So(apps[0].EnableSSH, ShouldEqual, true)
+	So(apps[0].DetectedStartCommand, ShouldEqual, "app-launching-service-broker")
+	So(apps[0].DockerImage, ShouldEqual, "")
+	So(apps[0].DockerCredentials["redacted_message"], ShouldEqual, "[PRIVATE DATA HIDDEN]")
+	So(apps[0].Environment["FOOBAR"], ShouldEqual, "QUX")
+	So(apps[0].StagingFailedReason, ShouldEqual, "")
+	So(apps[0].StagingFailedDescription, ShouldEqual, "")
+	So(apps[0].PackageState, ShouldEqual, "PENDING")
+	So(len(apps[0].Ports), ShouldEqual, 1)
+	So(apps[0].Ports[0], ShouldEqual, 8080)
+
+	So(apps[1].Guid, ShouldEqual, "f9ad202b-76dd-44ec-b7c2-fd2417a561e8")
+	So(apps[1].Name, ShouldEqual, "app-test2")
 }
 
 func TestAppByGuid(t *testing.T) {


### PR DESCRIPTION
* move to list apps to function of its own: listApps()
* reuse listApps() for ListAppsByQuery()
* reuse listApps for new function ListAppsByRoute()
* same for unit tests: assertAppList()