### PR TITLE
Provide limits capability for cfclient when querying app info

### DIFF
--- a/appevents_test.go
+++ b/appevents_test.go
@@ -23,7 +23,7 @@ func TestListAppEvents(t *testing.T) {
 		appEvents, err := client.ListAppEvents("blub")
 		So(err.Error(), ShouldEqual, "Unsupported app event type blub")
 		appEvents, err = client.ListAppEvents(AppCreate)
-		So(err, ShouldEqual, error(nil))
+		So(err, ShouldEqual, nil)
 		So(len(appEvents), ShouldEqual, 3)
 		So(appEvents[0].MetaData.Request.State, ShouldEqual, "STOPPED")
 		So(appEvents[1].EventType, ShouldEqual, AppCrash)
@@ -73,7 +73,7 @@ func TestListAppEventsByQuery(t *testing.T) {
 			Value:    "3ca436ff-67a8-468a-8c7d-27ec68a6cfe5",
 		}
 		appEvents, err = client.ListAppEventsByQuery(AppCreate, []AppEventQuery{appEventQuery})
-		So(err, ShouldEqual, error(nil))
+		So(err, ShouldEqual, nil)
 		So(len(appEvents), ShouldEqual, 3)
 		So(appEvents[0].MetaData.Request.State, ShouldEqual, "STOPPED")
 		So(appEvents[1].EventType, ShouldEqual, AppCrash)

--- a/appevents_test.go
+++ b/appevents_test.go
@@ -23,7 +23,7 @@ func TestListAppEvents(t *testing.T) {
 		appEvents, err := client.ListAppEvents("blub")
 		So(err.Error(), ShouldEqual, "Unsupported app event type blub")
 		appEvents, err = client.ListAppEvents(AppCreate)
-		So(err, ShouldEqual, nil)
+		So(err, ShouldEqual, error(nil))
 		So(len(appEvents), ShouldEqual, 3)
 		So(appEvents[0].MetaData.Request.State, ShouldEqual, "STOPPED")
 		So(appEvents[1].EventType, ShouldEqual, AppCrash)
@@ -73,7 +73,7 @@ func TestListAppEventsByQuery(t *testing.T) {
 			Value:    "3ca436ff-67a8-468a-8c7d-27ec68a6cfe5",
 		}
 		appEvents, err = client.ListAppEventsByQuery(AppCreate, []AppEventQuery{appEventQuery})
-		So(err, ShouldEqual, nil)
+		So(err, ShouldEqual, error(nil))
 		So(len(appEvents), ShouldEqual, 3)
 		So(appEvents[0].MetaData.Request.State, ShouldEqual, "STOPPED")
 		So(appEvents[1].EventType, ShouldEqual, AppCrash)

--- a/apps.go
+++ b/apps.go
@@ -177,7 +177,7 @@ func (a *App) Space() (Space, error) {
 // ListAppsByQueryWithLimits queries totalPages app info. When totalPages is
 // less and equal than 0, it queries all app info
 func (c *Client) ListAppsByQueryWithLimits(query url.Values, totalPages int) ([]App, error) {
-	return c.listApps("/v2/apps?" + query.Encode(), -1)
+	return c.listApps("/v2/apps?" + query.Encode(), totalPages)
 }
 
 func (c *Client) ListAppsByQuery(query url.Values) ([]App, error) {

--- a/apps.go
+++ b/apps.go
@@ -176,6 +176,7 @@ func (a *App) Space() (Space, error) {
 
 // ListAppsByQueryWithLimits queries totalPages app info. When totalPages is
 // less and equal than 0, it queries all app info
+// When there are no more than totalPages apps on server side, all apps info will be returned
 func (c *Client) ListAppsByQueryWithLimits(query url.Values, totalPages int) ([]App, error) {
 	return c.listApps("/v2/apps?" + query.Encode(), totalPages)
 }


### PR DESCRIPTION
Use case: I would like to query the latest 5000 apps and ignore the others in my super big env (50 K apps). The current REST API of CloudController doesn't support limiting the query results. This PR provide this support on client side