### PR TITLE
Add delete space method.

### DIFF
--- a/orgs.go
+++ b/orgs.go
@@ -448,8 +448,8 @@ func (c *Client) CreateOrg(req OrgRequest) (Org, error) {
 	return c.handleOrgResp(resp)
 }
 
-func (c *Client) DeleteOrg(guid string, recursive bool) error {
-	resp, err := c.DoRequest(c.NewRequest("DELETE", fmt.Sprintf("/v2/organizations/%s?recursive=%t", guid, recursive)))
+func (c *Client) DeleteOrg(guid string, recursive, async bool) error {
+	resp, err := c.DoRequest(c.NewRequest("DELETE", fmt.Sprintf("/v2/organizations/%s?recursive=%t&async=%t", guid, recursive, async)))
 	if err != nil {
 		return err
 	}

--- a/orgs_test.go
+++ b/orgs_test.go
@@ -155,7 +155,7 @@ func TestCreateOrg(t *testing.T) {
 
 func TestDeleteOrg(t *testing.T) {
 	Convey("Delete org", t, func() {
-		setup(MockRoute{"DELETE", "/v2/organizations/a537761f-9d93-4b30-af17-3d73dbca181b", "", "", 204, "recursive=false", nil}, t)
+		setup(MockRoute{"DELETE", "/v2/organizations/a537761f-9d93-4b30-af17-3d73dbca181b", "", "", 204, "recursive=false&async=false", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -164,7 +164,7 @@ func TestDeleteOrg(t *testing.T) {
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 
-		err = client.DeleteOrg("a537761f-9d93-4b30-af17-3d73dbca181b", false)
+		err = client.DeleteOrg("a537761f-9d93-4b30-af17-3d73dbca181b", false, false)
 		So(err, ShouldBeNil)
 	})
 }

--- a/spaces.go
+++ b/spaces.go
@@ -187,6 +187,17 @@ func (c *Client) CreateSpace(req SpaceRequest) (Space, error) {
 	return c.handleSpaceResp(resp)
 }
 
+func (c *Client) DeleteSpace(guid string, recursive, async bool) error {
+	resp, err := c.DoRequest(c.NewRequest("DELETE", fmt.Sprintf("/v2/spaces/%s?recursive=%t&async=%t", guid, recursive, async)))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return errors.Wrapf(err, "Error deleting space %s, response code: %d", guid, resp.StatusCode)
+	}
+	return nil
+}
+
 func (c *Client) AssociateSpaceDeveloperByUsername(spaceGUID, name string) (Space, error) {
 	space := Space{Guid: spaceGUID, c: c}
 	return space.AssociateDeveloperByUsername(name)

--- a/spaces_test.go
+++ b/spaces_test.go
@@ -69,6 +69,21 @@ func TestCreateSpace(t *testing.T) {
 	})
 }
 
+func TestDeleteSpace(t *testing.T) {
+	Convey("Delete org", t, func() {
+		setup(MockRoute{"DELETE", "/v2/spaces/a537761f-9d93-4b30-af17-3d73dbca181b", "", "", 204, "recursive=false&async=false", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		err = client.DeleteSpace("a537761f-9d93-4b30-af17-3d73dbca181b", false, false)
+		So(err, ShouldBeNil)
+	})
+}
 func TestSpaceOrg(t *testing.T) {
 	Convey("Find space org", t, func() {
 		setup(MockRoute{"GET", "/v2/org/foobar", orgPayload, "", 200, "", nil}, t)


### PR DESCRIPTION
Since query parameters to `DeleteOrg` are positional arguments, adding the recommended `async` flag winds up as a breaking change. I'm happy to revert if we're trying to avoid breaking changes. We could also allow delete methods to accept a `url.Values`.