### PR TITLE
Remove unnecessary conversions

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -183,7 +183,7 @@ func respBodyToDomain(body io.ReadCloser, c *Client) (*Domain, error) {
 		return nil, err
 	}
 	domainRes := DomainResource{}
-	err = json.Unmarshal([]byte(bodyRaw), &domainRes)
+	err = json.Unmarshal(bodyRaw, &domainRes)
 	if err != nil {
 		return nil, err
 	}

--- a/isolationsegments.go
+++ b/isolationsegments.go
@@ -76,7 +76,7 @@ func respBodyToIsolationSegment(body io.ReadCloser, c *Client) (*IsolationSegmen
 		return nil, err
 	}
 	isr := IsolationSegementResponse{}
-	err = json.Unmarshal([]byte(bodyRaw), &isr)
+	err = json.Unmarshal(bodyRaw, &isr)
 	if err != nil {
 		return nil, err
 	}

--- a/secgroups.go
+++ b/secgroups.go
@@ -275,7 +275,7 @@ func respBodyToSecGroup(body io.ReadCloser, c *Client) (*SecGroup, error) {
 	}
 	jStruct := SecGroupResource{}
 	//make it a SecGroup
-	err = json.Unmarshal([]byte(bodyRaw), &jStruct)
+	err = json.Unmarshal(bodyRaw, &jStruct)
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not unmarshal response body as json")
 	}

--- a/service_plan_visibilities.go
+++ b/service_plan_visibilities.go
@@ -89,7 +89,7 @@ func respBodyToServicePlanVisibility(body io.ReadCloser, c *Client) (ServicePlan
 		return ServicePlanVisibility{}, err
 	}
 	servicePlanVisibilityRes := ServicePlanVisibilityResource{}
-	err = json.Unmarshal([]byte(bodyRaw), &servicePlanVisibilityRes)
+	err = json.Unmarshal(bodyRaw, &servicePlanVisibilityRes)
 	if err != nil {
 		return ServicePlanVisibility{}, err
 	}


### PR DESCRIPTION
This patch removes the byte casting for raw bodies
during unmarshal since they are already byte arrays
due to ReadAll usage.

Signed-off-by: Marcela Bonell <marcelabonell@gmail.com>