### PR TITLE
Remove unused const and type in unit test

### DIFF
--- a/cf_test.go
+++ b/cf_test.go
@@ -35,10 +35,6 @@ func setup(mock MockRoute, t *testing.T) {
 	setupMultiple([]MockRoute{mock}, t)
 }
 
-type PostBody struct {
-	Data []map[string]string `json:"data"`
-}
-
 func testQueryString(QueryString string, QueryStringExp string, t *testing.T) {
 	value, _ := url.QueryUnescape(QueryString)
 

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -2580,24 +2580,6 @@ const listIsolationSegmentsPayload = `{
    ]
 }`
 
-const addOrgToIsolationSegmentPayload = `{
-   "guid": "033b4c58-12bb-499a-b05d-4b6fc9e2993b",
-   "name": "shared",
-   "created_at": "2016-10-19T20:25:04Z",
-   "updated_at": "2016-11-08T16:41:26Z",
-   "links": {
-      "self": {
-         "href": "https://api.example.org/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b"
-      },
-      "spaces": {
-         "href": "https://api.example.org/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b/relationships/spaces"
-      },
-      "organizations": {
-         "href": "https://api.example.org/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b/relationships/organizations"
-      }
-   }
-}`
-
 const listServiceKeysPayload = `{
    "total_results": 2,
    "total_pages": 1,


### PR DESCRIPTION
This patch removes unused code from unit tests, one
constant and one type were removed.

Signed-off-by: Marcela Bonell <marcelabonell@gmail.com>