### PR TITLE
Add support for service instance creation with parameters and/or tags

### DIFF
--- a/service_instances.go
+++ b/service_instances.go
@@ -18,9 +18,11 @@ type ServiceInstancesResponse struct {
 }
 
 type ServiceInstanceRequest struct {
-	Name            string `json:"name"`
-	SpaceGuid       string `json:"space_guid"`
-	ServicePlanGuid string `json:"service_plan_guid"`
+	Name            string                 `json:"name"`
+	SpaceGuid       string                 `json:"space_guid"`
+	ServicePlanGuid string                 `json:"service_plan_guid"`
+	Parameters      map[string]interface{} `json:"parameters,omitempty"`
+	Tags            []string               `json:"tags,omitempty"`
 }
 
 type ServiceInstanceResource struct {


### PR DESCRIPTION
Add "Parameters" and "Tags" to the ServiceInstanceRequest struct to allow providing parameters and tags to the service instance creation request.