### PR TITLE
Add support for Service Broker management APIs

### DIFF
--- a/payloads_test.go
+++ b/payloads_test.go
@@ -2813,3 +2813,37 @@ const listServiceBrokersPayload = `
   ]
 }
 `
+
+const getServiceByGuidPayload = `
+{
+  "metadata": {
+    "guid": "53f52780-e93c-4af7-a96c-6958311c40e5",
+    "url": "/v2/services/53f52780-e93c-4af7-a96c-6958311c40e5",
+    "created_at": "2016-06-08T16:41:32Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "label": "label-58",
+    "provider": null,
+    "url": null,
+    "description": "desc-135",
+    "long_description": null,
+    "version": null,
+    "info_url": null,
+    "active": true,
+    "bindable": true,
+    "unique_id": "c181996b-f233-43d1-8901-3a43eafcaacf",
+    "extra": null,
+    "tags": [
+
+    ],
+    "requires": [
+
+    ],
+    "documentation_url": null,
+    "service_broker_guid": "0e7250aa-364f-42c2-8fd2-808b0224376f",
+    "plan_updateable": false,
+    "service_plans_url": "/v2/services/53f52780-e93c-4af7-a96c-6958311c40e5/service_plans"
+  }
+}
+`

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -2788,3 +2788,28 @@ const postServiceKeysBadPayload = `{
   "error_code": "CF-ServiceKeyNameTaken",
   "code": 360001
 `
+
+const listServiceBrokersPayload = `
+{
+  "total_results": 3,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "90a413fd-a636-4133-8bfb-a94b07839e96",
+        "url": "/v2/service_brokers/90a413fd-a636-4133-8bfb-a94b07839e96",
+        "created_at": "2016-06-08T16:41:22Z",
+        "updated_at": "2016-06-08T16:41:22Z"
+      },
+      "entity": {
+        "name": "name-85",
+        "broker_url": "https://foo.com/url-2",
+        "auth_username": "auth_username-2",
+        "space_guid": "1d43e64d-ed64-43dd-9046-11f422bd407b"
+      }
+    }
+  ]
+}
+`

--- a/service_brokers.go
+++ b/service_brokers.go
@@ -1,0 +1,197 @@
+package cfclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+type ServiceBrokerResponse struct {
+	Count     int                     `json:"total_results"`
+	Pages     int                     `json:"total_pages"`
+	NextUrl   string                  `json:"next_url"`
+	Resources []ServiceBrokerResource `json:"resources"`
+}
+
+type ServiceBrokerResource struct {
+	Meta   Meta          `json:"metadata"`
+	Entity ServiceBroker `json:"entity"`
+}
+
+type UpdateServiceBrokerRequest struct {
+	Name      string `json:"name"`
+	BrokerURL string `json:"broker_url"`
+	Username  string `json:"auth_username"`
+	Password  string `json:"auth_password"`
+}
+
+type CreateServiceBrokerRequest struct {
+	Name      string `json:"name"`
+	BrokerURL string `json:"broker_url"`
+	Username  string `json:"auth_username"`
+	Password  string `json:"auth_password"`
+	SpaceGUID string `json:"space_guid,omitempty"`
+}
+
+type ServiceBroker struct {
+	Name      string `json:"name"`
+	BrokerURL string `json:"broker_url"`
+	Username  string `json:"auth_username"`
+	Password  string `json:"auth_password"`
+	SpaceGUID string `json:"space_guid,omitempty"`
+	c         *Client
+}
+
+func (c *Client) DeleteServiceBroker(guid string) error {
+	requestUrl := fmt.Sprintf("/v2/service_brokers/%s", guid)
+	r := c.NewRequest("DELETE", requestUrl)
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return errors.Wrapf(err, "Error deleteing service broker %s, response code: %d", guid, resp.StatusCode)
+	}
+	return nil
+
+}
+
+func (c *Client) UpdateServiceBroker(guid string, usb UpdateServiceBrokerRequest) (ServiceBroker, error) {
+	var serviceBrokerResource ServiceBrokerResource
+
+	buf := bytes.NewBuffer(nil)
+	err := json.NewEncoder(buf).Encode(usb)
+	if err != nil {
+		return ServiceBroker{}, err
+	}
+	req := c.NewRequestWithBody("PUT", fmt.Sprintf("/v2/service_brokers/%s", guid), buf)
+	resp, err := c.DoRequest(req)
+	if err != nil {
+		return ServiceBroker{}, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return ServiceBroker{}, fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return ServiceBroker{}, err
+	}
+	err = json.Unmarshal(body, &serviceBrokerResource)
+	if err != nil {
+		return ServiceBroker{}, err
+	}
+
+	return serviceBrokerResource.Entity, nil
+}
+
+func (c *Client) CreateServiceBroker(csb CreateServiceBrokerRequest) (ServiceBroker, error) {
+	var serviceBrokerResource ServiceBrokerResource
+
+	buf := bytes.NewBuffer(nil)
+	err := json.NewEncoder(buf).Encode(csb)
+	if err != nil {
+		return ServiceBroker{}, err
+	}
+	req := c.NewRequestWithBody("POST", "/v2/service_brokers", buf)
+	resp, err := c.DoRequest(req)
+	if err != nil {
+		return ServiceBroker{}, err
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return ServiceBroker{}, fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return ServiceBroker{}, err
+	}
+	err = json.Unmarshal(body, &serviceBrokerResource)
+	if err != nil {
+		return ServiceBroker{}, err
+	}
+
+	return serviceBrokerResource.Entity, nil
+}
+
+func (c *Client) ListServiceBrokersByQuery(query url.Values) ([]ServiceBroker, error) {
+	var sbs []ServiceBroker
+	requestUrl := "/v2/service_brokers?" + query.Encode()
+	for {
+		serviceBrokerResp, err := c.getServiceBrokerResponse(requestUrl)
+		if err != nil {
+			return []ServiceBroker{}, err
+		}
+		for _, sb := range serviceBrokerResp.Resources {
+			sbs = append(sbs, sb.Entity)
+		}
+		requestUrl = serviceBrokerResp.NextUrl
+		if requestUrl == "" {
+			break
+		}
+	}
+	return sbs, nil
+}
+
+func (c *Client) ListServiceBrokers() ([]ServiceBroker, error) {
+	return c.ListServiceBrokersByQuery(nil)
+}
+
+func (c *Client) GetServiceBrokerByGuid(guid string) (ServiceBroker, error) {
+	var serviceBrokerRes ServiceBrokerResource
+	r := c.NewRequest("GET", "/v2/service_brokers/"+guid)
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return ServiceBroker{}, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return ServiceBroker{}, err
+	}
+	err = json.Unmarshal(body, &serviceBrokerRes)
+	if err != nil {
+		return ServiceBroker{}, err
+	}
+	return serviceBrokerRes.Entity, nil
+}
+
+func (c *Client) GetServiceBrokerByName(name string) (ServiceBroker, error) {
+	var sb ServiceBroker
+	q := url.Values{}
+	q.Set("q", "name:"+name)
+	sbs, err := c.ListServiceBrokersByQuery(q)
+	if err != nil {
+		return sb, err
+	}
+	if len(sbs) == 0 {
+		return sb, fmt.Errorf("Unable to find service broker %s", name)
+	}
+	return sbs[0], nil
+}
+
+func (c *Client) getServiceBrokerResponse(requestUrl string) (ServiceBrokerResponse, error) {
+	var serviceBrokerResp ServiceBrokerResponse
+	r := c.NewRequest("GET", requestUrl)
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return ServiceBrokerResponse{}, errors.Wrap(err, "Error requesting Service Brokers")
+	}
+	resBody, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return ServiceBrokerResponse{}, errors.Wrap(err, "Error reading Service Broker request")
+	}
+	err = json.Unmarshal(resBody, &serviceBrokerResp)
+	if err != nil {
+		return ServiceBrokerResponse{}, errors.Wrap(err, "Error unmarshalling Service Broker")
+	}
+	return serviceBrokerResp, nil
+}

--- a/service_brokers_test.go
+++ b/service_brokers_test.go
@@ -1,0 +1,30 @@
+package cfclient
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestListServiceBrokers(t *testing.T) {
+	Convey("List Service Brokers", t, func() {
+		setup(MockRoute{"GET", "/v2/service_brokers", listServiceBrokersPayload, "", 200, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		servicePlans, err := client.ListServiceBrokers()
+		So(err, ShouldBeNil)
+
+		So(len(servicePlans), ShouldEqual, 1)
+		So(servicePlans[0].Name, ShouldEqual, "name-85")
+		So(servicePlans[0].BrokerURL, ShouldEqual, "https://foo.com/url-2")
+		So(servicePlans[0].Username, ShouldEqual, "auth_username-2")
+		So(servicePlans[0].SpaceGUID, ShouldEqual, "1d43e64d-ed64-43dd-9046-11f422bd407b")
+		So(servicePlans[0].Password, ShouldBeEmpty)
+	})
+}

--- a/service_instances.go
+++ b/service_instances.go
@@ -18,9 +18,11 @@ type ServiceInstancesResponse struct {
 }
 
 type ServiceInstanceRequest struct {
-	Name            string `json:"name"`
-	SpaceGuid       string `json:"space_guid"`
-	ServicePlanGuid string `json:"service_plan_guid"`
+	Name            string                 `json:"name"`
+	SpaceGuid       string                 `json:"space_guid"`
+	ServicePlanGuid string                 `json:"service_plan_guid"`
+	Parameters      map[string]interface{} `json:"parameters,omitempty"`
+	Tags            []string               `json:"tags,omitempty"`
 }
 
 type ServiceInstanceResource struct {

--- a/service_plans.go
+++ b/service_plans.go
@@ -2,7 +2,6 @@ package cfclient
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/url"
 
@@ -12,6 +11,7 @@ import (
 type ServicePlansResponse struct {
 	Count     int                   `json:"total_results"`
 	Pages     int                   `json:"total_pages"`
+	NextUrl   string                `json:"next_url"`
 	Resources []ServicePlanResource `json:"resources"`
 }
 
@@ -38,14 +38,10 @@ type ServicePlan struct {
 
 func (c *Client) ListServicePlansByQuery(query url.Values) ([]ServicePlan, error) {
 	var servicePlans []ServicePlan
-	if query == nil {
-		query = url.Values{}
-	}
-	done := false
-	for currPage := 1; !done; currPage++ {
+	requestUrl := "/v2/service_plans?" + query.Encode()
+	for {
 		var servicePlansResp ServicePlansResponse
-		query.Set("page", fmt.Sprintf("%d", currPage))
-		r := c.NewRequest("GET", "/v2/service_plans?"+query.Encode())
+		r := c.NewRequest("GET", requestUrl)
 		resp, err := c.DoRequest(r)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error requesting service plans")
@@ -54,16 +50,18 @@ func (c *Client) ListServicePlansByQuery(query url.Values) ([]ServicePlan, error
 		if err != nil {
 			return nil, errors.Wrap(err, "Error reading service plans request:")
 		}
-
 		err = json.Unmarshal(resBody, &servicePlansResp)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error unmarshaling service plans")
 		}
-		done = (servicePlansResp.Pages == currPage)
 		for _, servicePlan := range servicePlansResp.Resources {
 			servicePlan.Entity.Guid = servicePlan.Meta.Guid
 			servicePlan.Entity.c = c
 			servicePlans = append(servicePlans, servicePlan.Entity)
+		}
+		requestUrl = servicePlansResp.NextUrl
+		if requestUrl == "" {
+			break
 		}
 	}
 	return servicePlans, nil

--- a/services.go
+++ b/services.go
@@ -21,15 +21,42 @@ type ServicesResource struct {
 }
 
 type Service struct {
-	Guid  string `json:"guid"`
-	Label string `json:"label"`
-	c     *Client
+	Guid              string   `json:"guid"`
+	Label             string   `json:"label"`
+	Description       string   `json:"description"`
+	Active            bool     `json:"active"`
+	Bindable          bool     `json:"bindable"`
+	ServiceBrokerGuid string   `json:"service_broker_guid"`
+	PlanUpdateable    bool     `json:"plan_updateable"`
+	Tags              []string `json:"tags"`
+	c                 *Client
 }
 
 type ServiceSummary struct {
 	Guid          string `json:"guid"`
 	Name          string `json:"name"`
 	BoundAppCount int    `json:"bound_app_count"`
+}
+
+func (c *Client) GetServiceByGuid(guid string) (Service, error) {
+	var serviceRes ServicesResource
+	r := c.NewRequest("GET", "/v2/services/"+guid)
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return Service{}, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return Service{}, err
+	}
+	err = json.Unmarshal(body, &serviceRes)
+	if err != nil {
+		return Service{}, err
+	}
+	serviceRes.Entity.Guid = serviceRes.Meta.Guid
+	return serviceRes.Entity, nil
+
 }
 
 func (c *Client) ListServicesByQuery(query url.Values) ([]Service, error) {

--- a/services_test.go
+++ b/services_test.go
@@ -23,5 +23,44 @@ func TestListServices(t *testing.T) {
 		So(len(services), ShouldEqual, 2)
 		So(services[0].Guid, ShouldEqual, "a3d76c01-c08a-4505-b06d-8603265682a3")
 		So(services[0].Label, ShouldEqual, "nats")
+		So(services[0].Description, ShouldEqual, "NATS is a lightweight cloud messaging system")
+		So(services[0].Active, ShouldEqual, true)
+		So(services[0].Bindable, ShouldEqual, true)
+		So(services[0].PlanUpdateable, ShouldEqual, false)
+		So(services[1].ServiceBrokerGuid, ShouldEqual, "a4bdf03a-f0c4-43f9-9c77-f434da91404f")
+		So(services[1].Guid, ShouldEqual, "ab9ad9c8-1f51-463a-ae3a-5082e9f04ae6")
+		So(services[1].Label, ShouldEqual, "etcd")
+		So(services[1].Description, ShouldEqual, "Etcd key-value storage")
+		So(services[1].Active, ShouldEqual, true)
+		So(services[1].Bindable, ShouldEqual, true)
+		So(services[1].PlanUpdateable, ShouldEqual, false)
+		So(services[1].ServiceBrokerGuid, ShouldEqual, "a4bdf03a-f0c4-43f9-9c77-f434da91404f")
+		So(len(services[1].Tags), ShouldEqual, 3)
+		So(services[1].Tags[0], ShouldEqual, "etcd")
+		So(services[1].Tags[1], ShouldEqual, "keyvalue")
+		So(services[1].Tags[2], ShouldEqual, "etcd-0.4.6")
+	})
+}
+
+func TestGetServiceByGuid(t *testing.T) {
+	Convey("Get Service By Guid", t, func() {
+		setup(MockRoute{"GET", "/v2/services/53f52780-e93c-4af7-a96c-6958311c40e5", getServiceByGuidPayload, "", 200, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		service, err := client.GetServiceByGuid("53f52780-e93c-4af7-a96c-6958311c40e5")
+		So(err, ShouldBeNil)
+
+		So(service.Guid, ShouldEqual, "53f52780-e93c-4af7-a96c-6958311c40e5")
+		So(service.Label, ShouldEqual, "label-58")
+		So(service.Description, ShouldEqual, "desc-135")
+		So(service.Active, ShouldEqual, true)
+		So(service.Bindable, ShouldEqual, true)
+		So(service.PlanUpdateable, ShouldEqual, false)
 	})
 }


### PR DESCRIPTION
This commit adds:
1.  support in the library for the [service broker management APIs](https://apidocs.cloudfoundry.org/272/#service-brokers).
2.  fixes a bug in ListServicesByQuery and ListServicePlansByQuery where only the first page of results would be returned instead of all of the results.
3. adds GetServiceByGuid

