### PR TITLE
Add timestamps to buildpacks

### DIFF
--- a/buildpacks.go
+++ b/buildpacks.go
@@ -20,12 +20,14 @@ type BuildpackResource struct {
 }
 
 type Buildpack struct {
-	Guid     string `json:"guid"`
-	Name     string `json:"name"`
-	Enabled  bool   `json:"enabled"`
-	Locked   bool   `json:"locked"`
-	Filename string `json:"filename"`
-	c        *Client
+	Guid      string `json:"guid"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+	Name      string `json:"name"`
+	Enabled   bool   `json:"enabled"`
+	Locked    bool   `json:"locked"`
+	Filename  string `json:"filename"`
+	c         *Client
 }
 
 func (c *Client) ListBuildpacks() ([]Buildpack, error) {
@@ -37,9 +39,7 @@ func (c *Client) ListBuildpacks() ([]Buildpack, error) {
 			return []Buildpack{}, err
 		}
 		for _, buildpack := range buildpackResp.Resources {
-			buildpack.Entity.Guid = buildpack.Meta.Guid
-			buildpack.Entity.c = c
-			buildpacks = append(buildpacks, buildpack.Entity)
+			buildpacks = append(buildpacks, c.mergeBuildpackResource(buildpack))
 		}
 		requestUrl = buildpackResp.NextUrl
 		if requestUrl == "" {
@@ -66,4 +66,12 @@ func (c *Client) getBuildpackResponse(requestUrl string) (BuildpackResponse, err
 		return BuildpackResponse{}, errors.Wrap(err, "Error unmarshalling buildpack")
 	}
 	return buildpackResp, nil
+}
+
+func (c *Client) mergeBuildpackResource(buildpack BuildpackResource) Buildpack {
+	buildpack.Entity.Guid = buildpack.Meta.Guid
+	buildpack.Entity.CreatedAt = buildpack.Meta.CreatedAt
+	buildpack.Entity.UpdatedAt = buildpack.Meta.UpdatedAt
+	buildpack.Entity.c = c
+	return buildpack.Entity
 }

--- a/buildpacks_test.go
+++ b/buildpacks_test.go
@@ -26,6 +26,8 @@ func TestListBuildpacks(t *testing.T) {
 
 		So(len(buildpacks), ShouldEqual, 6)
 		So(buildpacks[0].Guid, ShouldEqual, "c92b6f5f-d2a4-413a-b515-647d059723aa")
+		So(buildpacks[0].CreatedAt, ShouldEqual, "2016-06-08T16:41:31Z")
+		So(buildpacks[0].UpdatedAt, ShouldEqual, "2016-06-08T16:41:26Z")
 		So(buildpacks[0].Name, ShouldEqual, "name_1")
 	})
 }


### PR DESCRIPTION
Similar to
https://github.com/cloudfoundry-community/go-cfclient/pull/125

It would be nice to have timestamps for buildpacks in order to compare
based on the timestamps