### PR TITLE
Respect expiration of password token source

### DIFF
--- a/cf_test.go
+++ b/cf_test.go
@@ -68,7 +68,7 @@ func testPostQuery(req *http.Request, postFormBody *string, t *testing.T) {
 func setupMultiple(mockEndpoints []MockRoute, t *testing.T) {
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
-	fakeUAAServer = FakeUAAServer()
+	fakeUAAServer = FakeUAAServer(3)
 	m := martini.New()
 	m.Use(render.Renderer())
 	r := martini.NewRouter()
@@ -120,7 +120,7 @@ func setupMultiple(mockEndpoints []MockRoute, t *testing.T) {
 	mux.Handle("/", m)
 }
 
-func FakeUAAServer() *httptest.Server {
+func FakeUAAServer(expiresIn int) *httptest.Server {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 	m := martini.New()
@@ -132,7 +132,7 @@ func FakeUAAServer() *httptest.Server {
 			"token_type":    "bearer",
 			"access_token":  "foobar" + strconv.Itoa(count),
 			"refresh_token": "barfoo",
-			"expires_in":    3,
+			"expires_in":    expiresIn,
 		})
 		count = count + 1
 	})

--- a/client.go
+++ b/client.go
@@ -158,12 +158,11 @@ func getUserAuth(ctx context.Context, config Config, endpoint *Endpoint) (Config
 	}
 
 	token, err := authConfig.PasswordCredentialsToken(ctx, config.Username, config.Password)
-	config.tokenSourceDeadline = &token.Expiry
-
 	if err != nil {
 		return config, errors.Wrap(err, "Error getting token")
 	}
 
+	config.tokenSourceDeadline = &token.Expiry
 	config.TokenSource = authConfig.TokenSource(ctx, token)
 	config.HttpClient = oauth2.NewClient(ctx, config.TokenSource)
 


### PR DESCRIPTION
When using username/password authentication the Client fetches a token on creation to be used as the token source. This token expires eventually and is only refreshable by creating a new Client object.

Capture the expiration of the token and refresh the oauth client when it expires.

fixes #34
updates cloudfoundry-community/stackdriver-tools#177