### PR TITLE
Added "omitempty" for optional parameters

### DIFF
--- a/spaces.go
+++ b/spaces.go
@@ -15,13 +15,13 @@ import (
 type SpaceRequest struct {
 	Name               string   `json:"name"`
 	OrganizationGuid   string   `json:"organization_guid"`
-	DeveloperGuid      []string `json:"developer_guids"`
-	ManagerGuid        []string `json:"manager_guids"`
-	AuditorGuid        []string `json:"auditor_guids"`
-	DomainGuid         []string `json:"domain_guids"`
-	SecurityGroupGuids []string `json:"security_group_guids"`
-	SpaceQuotaDefGuid  string   `json:"space_quota_definition_guid"`
-	AllowSSH           bool     `json:"allow_ssh"`
+	DeveloperGuid      []string `json:"developer_guids,omitempty"`
+	ManagerGuid        []string `json:"manager_guids,omitempty"`
+	AuditorGuid        []string `json:"auditor_guids,omitempty"`
+	DomainGuid         []string `json:"domain_guids,omitempty"`
+	SecurityGroupGuids []string `json:"security_group_guids,omitempty"`
+	SpaceQuotaDefGuid  string   `json:"space_quota_definition_guid,omitempty"`
+	AllowSSH           bool     `json:"allow_ssh,omitempty"`
 }
 
 type SpaceResponse struct {


### PR DESCRIPTION
Without the "omitempty" parts, the GO marsheller adds "nil" entries to the request for all the arrays in the request structure. Cloud Foundry fails to create the space with an  error:

cfclient: error (1002): CF-InvalidRelation

This error is fixed by adding "omitempty" to the non-required parts of the request.
