### PR TITLE
Add CreatedAt to event resource

### DIFF
--- a/events.go
+++ b/events.go
@@ -26,6 +26,7 @@ type EventResource struct {
 type Event struct {
 	GUID             string `json:"guid"`
 	Type             string `json:"type"`
+	CreatedAt        string `json:"created_at"`
 	Actor            string `json:"actor"`
 	ActorType        string `json:"actor_type"`
 	ActorName        string `json:"actor_name"`
@@ -55,6 +56,7 @@ func (c *Client) ListEventsByQuery(query url.Values) ([]Event, error) {
 		}
 		for _, e := range eventResp.Resources {
 			e.Entity.GUID = e.Meta.Guid
+			e.Entity.CreatedAt = e.Meta.CreatedAt
 			e.Entity.c = c
 			events = append(events, e.Entity)
 		}

--- a/events_test.go
+++ b/events_test.go
@@ -27,6 +27,7 @@ func TestListEvents(t *testing.T) {
 		So(len(events), ShouldEqual, 4)
 		So(events[0].GUID, ShouldEqual, "b8ede8e1-afc8-40a1-baae-236a0a77b27b")
 		So(events[0].Actor, ShouldEqual, "guid-008640fc-d316-4602-9251-c8d09bbdc750")
+		So(events[0].CreatedAt, ShouldEqual, "2016-06-08T16:41:23Z")
 	})
 }
 


### PR DESCRIPTION
Hi, 

I was using your library to get a list events, but I found out that the library didn't expose the time each of these events was created. That timestamp is really relevant for auditing to know when something happened.


Please, let me know if you need further changes.