### PR TITLE
Fix bug that expects cf api to return status 204 when removing a user…

### DIFF
--- a/spaces.go
+++ b/spaces.go
@@ -377,7 +377,7 @@ func (s *Space) RemoveDeveloperByUsername(name string) error {
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != http.StatusNoContent {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -412,7 +412,7 @@ func (s *Space) RemoveAuditorByUsername(name string) error {
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != http.StatusNoContent {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil

--- a/spaces_test.go
+++ b/spaces_test.go
@@ -335,7 +335,7 @@ func TestAssociateSpaceDeveloperByUsername(t *testing.T) {
 
 func TestRemoveSpaceDeveloperByUsername(t *testing.T) {
 	Convey("Remove developer by username", t, func() {
-		setup(MockRoute{"DELETE", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/developers", "", "", 204, "", nil}, t)
+		setup(MockRoute{"DELETE", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/developers", "", "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -355,7 +355,7 @@ func TestRemoveSpaceDeveloperByUsername(t *testing.T) {
 }
 func TestRemoveSpaceAuditorByUsername(t *testing.T) {
 	Convey("Remove auditor by username", t, func() {
-		setup(MockRoute{"DELETE", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", "", "", 204, "", nil}, t)
+		setup(MockRoute{"DELETE", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", "", "", 200, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,


### PR DESCRIPTION
… as a space dev or auditor

This PR would change the error in RemoveDeveloperByUsername to occur on non 200 status rather thatn 204.

According to CC API docs `DELETE v2/spaces/space_guid/developers` was added in version 2.53.0 and the success status was `200 OK` 
https://apidocs.cloudfoundry.org/234/spaces/remove_developer_with_the_space_by_username.html

The newest version still defines sucess as `200 OK`
https://apidocs.cloudfoundry.org/280/spaces/remove_developer_with_the_space_by_username.html

Signed-off-by: Satheesh Uppalapati <suppalapati79@gmail.com>