### PR TITLE
Removing trailing slashes from the API Address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 sudo: false
 go:
-  - 1.8
-  - 1.9
-  - tip
+  - "1.9"
+  - "1.10"
+  - "tip"
 
 before_install:
   - go get -u golang.org/x/tools/cmd/goimports

--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"time"
 
@@ -127,6 +128,8 @@ func NewClient(config *Config) (client *Client, err error) {
 		}
 		tp.TLSClientConfig.InsecureSkipVerify = config.SkipSslValidation
 	}
+
+	config.ApiAddress = strings.TrimRight(config.ApiAddress, "/")
 
 	client = &Client{
 		Config: *config,

--- a/client_test.go
+++ b/client_test.go
@@ -21,6 +21,19 @@ func TestDefaultConfig(t *testing.T) {
 	})
 }
 
+func TestRemovalofTrailingSlashOnAPIAddress(t *testing.T) {
+	Convey("Test removal of trailing slash of the API Address", t, func() {
+		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, "", 200, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL + "/",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+		So(client.Config.ApiAddress, ShouldNotEndWith, "/")
+	})
+}
+
 func TestMakeRequest(t *testing.T) {
 	Convey("Test making request b", t, func() {
 		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, "", 200, "", nil}, t)
@@ -105,9 +118,9 @@ func TestEndpointRefresh(t *testing.T) {
 		fakeUAAServer = FakeUAAServer(0)
 
 		c := &Config{
-			ApiAddress:         server.URL,
-			Username:           "foo",
-			Password:           "bar",
+			ApiAddress: server.URL,
+			Username:   "foo",
+			Password:   "bar",
 		}
 
 		client, err := NewClient(c)


### PR DESCRIPTION
This has caused us multiple hours of headaches where the cloud controller would not honor the query params if there was a double slash in the URL. 
Note: this does not happen against every CF environment, it appears to depend on the load balancer before the routers.
To avoid that, we just remove the trailing slash of the API Address.

Co-authored-by: Adham Abdelwahab <ahelal@users.noreply.github.com>