### PR TITLE
Adding additional API features

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -192,3 +192,28 @@ func respBodyToDomain(body io.ReadCloser, c *Client) (*Domain, error) {
 	domain.c = c
 	return &domain, nil
 }
+
+func (c *Client) getDomainsResponse(requestUrl string) (DomainsResponse, error) {
+	var domainResp DomainsResponse
+	r := c.NewRequest("GET", requestUrl)
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return DomainsResponse{}, errors.Wrap(err, "Error requesting domains")
+	}
+	resBody, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return DomainsResponse{}, errors.Wrap(err, "Error reading domains request")
+	}
+	err = json.Unmarshal(resBody, &domainResp)
+	if err != nil {
+		return DomainsResponse{}, errors.Wrap(err, "Error unmarshalling org")
+	}
+	return domainResp, nil
+}
+
+func (c *Client) mergeDomainResource(domainResource DomainResource) *Domain {
+	domainResource.Entity.Guid = domainResource.Meta.Guid
+	domainResource.Entity.c = c
+	return &domainResource.Entity
+}

--- a/org_quotas.go
+++ b/org_quotas.go
@@ -1,9 +1,11 @@
 package cfclient
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 
 	"github.com/pkg/errors"
@@ -21,9 +23,26 @@ type OrgQuotasResource struct {
 	Entity OrgQuota `json:"entity"`
 }
 
+type OrgQuotaRequest struct {
+	Name                    string `json:"name"`
+	NonBasicServicesAllowed bool   `json:"non_basic_services_allowed"`
+	TotalServices           int    `json:"total_services"`
+	TotalRoutes             int    `json:"total_routes"`
+	TotalPrivateDomains     int    `json:"total_private_domains"`
+	MemoryLimit             int    `json:"memory_limit"`
+	TrialDBAllowed          bool   `json:"trial_db_allowed"`
+	InstanceMemoryLimit     int    `json:"instance_memory_limit"`
+	AppInstanceLimit        int    `json:"app_instance_limit"`
+	AppTaskLimit            int    `json:"app_task_limit"`
+	TotalServiceKeys        int    `json:"total_service_keys"`
+	TotalReservedRoutePorts int    `json:"total_reserved_route_ports"`
+}
+
 type OrgQuota struct {
 	Guid                    string `json:"guid"`
 	Name                    string `json:"name"`
+	CreatedAt               string `json:"created_at,omitempty"`
+	UpdatedAt               string `json:"updated_at,omitempty"`
 	NonBasicServicesAllowed bool   `json:"non_basic_services_allowed"`
 	TotalServices           int    `json:"total_services"`
 	TotalRoutes             int    `json:"total_routes"`
@@ -93,4 +112,60 @@ func (c *Client) getOrgQuotasResponse(requestUrl string) (OrgQuotasResponse, err
 		return OrgQuotasResponse{}, errors.Wrap(err, "Error unmarshalling org quotas")
 	}
 	return orgQuotasResp, nil
+}
+
+func (c *Client) CreateOrgQuota(orgQuote OrgQuotaRequest) (*OrgQuota, error) {
+	buf := bytes.NewBuffer(nil)
+	err := json.NewEncoder(buf).Encode(orgQuote)
+	if err != nil {
+		return nil, err
+	}
+	r := c.NewRequestWithBody("POST", "/v2/quota_definitions", buf)
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
+	}
+	return c.handleOrgQuotaResp(resp)
+}
+
+func (c *Client) UpdateOrgQuota(orgQuotaGUID string, orgQuota OrgQuotaRequest) (*OrgQuota, error) {
+	buf := bytes.NewBuffer(nil)
+	err := json.NewEncoder(buf).Encode(orgQuota)
+	if err != nil {
+		return nil, err
+	}
+	r := c.NewRequestWithBody("PUT", fmt.Sprintf("/v2/quota_definitions/%s", orgQuotaGUID), buf)
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
+	}
+	return c.handleOrgQuotaResp(resp)
+}
+
+func (c *Client) handleOrgQuotaResp(resp *http.Response) (*OrgQuota, error) {
+	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	var orgQuotasResource OrgQuotasResource
+	err = json.Unmarshal(body, &orgQuotasResource)
+	if err != nil {
+		return nil, err
+	}
+	return c.mergeOrgQuotaResource(orgQuotasResource), nil
+}
+
+func (c *Client) mergeOrgQuotaResource(orgQuotaResource OrgQuotasResource) *OrgQuota {
+	orgQuotaResource.Entity.Guid = orgQuotaResource.Meta.Guid
+	orgQuotaResource.Entity.CreatedAt = orgQuotaResource.Meta.CreatedAt
+	orgQuotaResource.Entity.UpdatedAt = orgQuotaResource.Meta.UpdatedAt
+	orgQuotaResource.Entity.c = c
+	return &orgQuotaResource.Entity
 }

--- a/org_quotas_test.go
+++ b/org_quotas_test.go
@@ -70,3 +70,49 @@ func TestGetOrgQuotaByName(t *testing.T) {
 		So(orgQuota.TotalReservedRoutePorts, ShouldEqual, 90)
 	})
 }
+
+func TestCreateOrgQuota(t *testing.T) {
+	Convey("Create Org Quota", t, func() {
+		setup(MockRoute{"POST", "/v2/quota_definitions", orgQuotaPayload, "", 201, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		orgQuotaRequest := OrgQuotaRequest{
+			Name: "test-2",
+		}
+
+		orgQuota, err := client.CreateOrgQuota(orgQuotaRequest)
+		So(err, ShouldBeNil)
+
+		So(orgQuota.Name, ShouldEqual, "test-2")
+
+	})
+}
+
+func TestUpdateOrgQuota(t *testing.T) {
+	Convey("Create Update Quota", t, func() {
+		setup(MockRoute{"PUT", "/v2/quota_definitions/9ffd7c5c-d83c-4786-b399-b7bd54883977", orgQuotaPayload, "", 201, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		orgQuotaRequest := OrgQuotaRequest{
+			Name: "test-2",
+		}
+
+		orgQuota, err := client.UpdateOrgQuota("9ffd7c5c-d83c-4786-b399-b7bd54883977", orgQuotaRequest)
+		So(err, ShouldBeNil)
+
+		So(orgQuota.Name, ShouldEqual, "test-2")
+
+	})
+}

--- a/orgs.go
+++ b/orgs.go
@@ -32,12 +32,13 @@ type OrgUserResponse struct {
 }
 
 type Org struct {
-	Guid                string `json:"guid"`
-	CreatedAt           string `json:"created_at"`
-	UpdatedAt           string `json:"updated_at"`
-	Name                string `json:"name"`
-	QuotaDefinitionGuid string `json:"quota_definition_guid"`
-	c                   *Client
+	Guid                        string `json:"guid"`
+	CreatedAt                   string `json:"created_at"`
+	UpdatedAt                   string `json:"updated_at"`
+	Name                        string `json:"name"`
+	QuotaDefinitionGuid         string `json:"quota_definition_guid"`
+	DefaultIsolationSegmentGuid string `json:"default_isolation_segment_guid"`
+	c                           *Client
 }
 
 type OrgSummary struct {
@@ -57,9 +58,10 @@ type OrgSummarySpaces struct {
 }
 
 type OrgRequest struct {
-	Name                string `json:"name"`
-	Status              string `json:"status,omitempty"`
-	QuotaDefinitionGuid string `json:"quota_definition_guid,omitempty"`
+	Name                        string `json:"name"`
+	Status                      string `json:"status,omitempty"`
+	QuotaDefinitionGuid         string `json:"quota_definition_guid,omitempty"`
+	DefaultIsolationSegmentGuid string `json:"default_isolation_segment_guid,omitempty"`
 }
 
 func (c *Client) ListOrgsByQuery(query url.Values) ([]Org, error) {
@@ -547,6 +549,23 @@ func (c *Client) CreateOrg(req OrgRequest) (Org, error) {
 	}
 	if resp.StatusCode != http.StatusCreated {
 		return Org{}, errors.Wrapf(err, "Error creating organization, response code: %d", resp.StatusCode)
+	}
+	return c.handleOrgResp(resp)
+}
+
+func (c *Client) UpdateOrg(orgRequest OrgRequest) (Org, error) {
+	buf := bytes.NewBuffer(nil)
+	err := json.NewEncoder(buf).Encode(orgRequest)
+	if err != nil {
+		return Org{}, err
+	}
+	r := c.NewRequestWithBody("PUT", "/v2/organizations", buf)
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return Org{}, err
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return Org{}, errors.Wrapf(err, "Error updating organization, response code: %d", resp.StatusCode)
 	}
 	return c.handleOrgResp(resp)
 }

--- a/orgs.go
+++ b/orgs.go
@@ -252,12 +252,12 @@ func (c *Client) ListOrgAuditors(orgGUID string) ([]User, error) {
 	return c.ListOrgAuditorsByQuery(orgGUID, nil)
 }
 
-func (c *Client) ListBillingManagersByQuery(orgGUID string, query url.Values) ([]User, error) {
+func (c *Client) ListOrgBillingManagersByQuery(orgGUID string, query url.Values) ([]User, error) {
 	return c.listOrgRolesByQuery(orgGUID, "billing_managers", query)
 }
 
-func (c *Client) ListBillingManagers(orgGUID string) ([]User, error) {
-	return c.ListBillingManagersByQuery(orgGUID, nil)
+func (c *Client) ListOrgBillingManagers(orgGUID string) ([]User, error) {
+	return c.ListOrgBillingManagersByQuery(orgGUID, nil)
 }
 
 func (c *Client) AssociateOrgManager(orgGUID, userGUID string) (Org, error) {

--- a/orgs.go
+++ b/orgs.go
@@ -553,13 +553,13 @@ func (c *Client) CreateOrg(req OrgRequest) (Org, error) {
 	return c.handleOrgResp(resp)
 }
 
-func (c *Client) UpdateOrg(orgRequest OrgRequest) (Org, error) {
+func (c *Client) UpdateOrg(orgGUID string, orgRequest OrgRequest) (Org, error) {
 	buf := bytes.NewBuffer(nil)
 	err := json.NewEncoder(buf).Encode(orgRequest)
 	if err != nil {
 		return Org{}, err
 	}
-	r := c.NewRequestWithBody("PUT", "/v2/organizations", buf)
+	r := c.NewRequestWithBody("PUT", fmt.Sprintf("/v2/organizations/%s", orgGUID), buf)
 	resp, err := c.DoRequest(r)
 	if err != nil {
 		return Org{}, err

--- a/orgs.go
+++ b/orgs.go
@@ -345,6 +345,11 @@ func (c *Client) ListOrgSpaceQuotas(orgGUID string) ([]SpaceQuota, error) {
 	return org.ListSpaceQuotas()
 }
 
+func (c *Client) ListOrgPrivateDomains(orgGUID string) ([]Domain, error) {
+	org := Org{Guid: orgGUID, c: c}
+	return org.ListPrivateDomains()
+}
+
 func (o *Org) ListSpaceQuotas() ([]SpaceQuota, error) {
 	var spaceQuotas []SpaceQuota
 	requestURL := fmt.Sprintf("/v2/organizations/%s/space_quota_definitions", o.Guid)
@@ -362,6 +367,25 @@ func (o *Org) ListSpaceQuotas() ([]SpaceQuota, error) {
 		}
 	}
 	return spaceQuotas, nil
+}
+
+func (o *Org) ListPrivateDomains() ([]Domain, error) {
+	var domains []Domain
+	requestURL := fmt.Sprintf("/v2/organizations/%s/private_domains", o.Guid)
+	for {
+		domainsResp, err := o.c.getDomainsResponse(requestURL)
+		if err != nil {
+			return []Domain{}, err
+		}
+		for _, resource := range domainsResp.Resources {
+			domains = append(domains, *o.c.mergeDomainResource(resource))
+		}
+		requestURL = domainsResp.NextUrl
+		if requestURL == "" {
+			break
+		}
+	}
+	return domains, nil
 }
 
 func (o *Org) associateRole(userGUID, role string) (Org, error) {

--- a/orgs_test.go
+++ b/orgs_test.go
@@ -258,6 +258,23 @@ func TestCreateOrg(t *testing.T) {
 	})
 }
 
+func TestUpdateOrg(t *testing.T) {
+	Convey("Update org", t, func() {
+		setup(MockRoute{"PUT", "/v2/organizations", createOrgPayload, "", 201, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		org, err := client.UpdateOrg(OrgRequest{Name: "my-org"})
+		So(err, ShouldBeNil)
+		So(org.Guid, ShouldEqual, "22b3b0a0-6511-47e5-8f7a-93bbd2ff446e")
+	})
+}
+
 func TestDeleteOrg(t *testing.T) {
 	Convey("Delete org", t, func() {
 		setup(MockRoute{"DELETE", "/v2/organizations/a537761f-9d93-4b30-af17-3d73dbca181b", "", "", 204, "recursive=false&async=false", nil}, t)

--- a/orgs_test.go
+++ b/orgs_test.go
@@ -260,7 +260,7 @@ func TestCreateOrg(t *testing.T) {
 
 func TestUpdateOrg(t *testing.T) {
 	Convey("Update org", t, func() {
-		setup(MockRoute{"PUT", "/v2/organizations", createOrgPayload, "", 201, "", nil}, t)
+		setup(MockRoute{"PUT", "/v2/organizations/22b3b0a0-6511-47e5-8f7a-93bbd2ff446e", createOrgPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -269,7 +269,7 @@ func TestUpdateOrg(t *testing.T) {
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 
-		org, err := client.UpdateOrg(OrgRequest{Name: "my-org"})
+		org, err := client.UpdateOrg("22b3b0a0-6511-47e5-8f7a-93bbd2ff446e", OrgRequest{Name: "my-org"})
 		So(err, ShouldBeNil)
 		So(org.Guid, ShouldEqual, "22b3b0a0-6511-47e5-8f7a-93bbd2ff446e")
 	})

--- a/orgs_test.go
+++ b/orgs_test.go
@@ -166,7 +166,7 @@ func TestListBillingManagers(t *testing.T) {
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 
-		managers, err := client.ListBillingManagers("foo")
+		managers, err := client.ListOrgBillingManagers("foo")
 		So(err, ShouldBeNil)
 		So(len(managers), ShouldEqual, 2)
 		So(managers[0].Username, ShouldEqual, "user1")

--- a/orgs_test.go
+++ b/orgs_test.go
@@ -689,3 +689,45 @@ func TestListOrgPrivateDomains(t *testing.T) {
 
 	})
 }
+
+func TestShareOrgPrivateDomain(t *testing.T) {
+	Convey("Share Org Private Domain", t, func() {
+		mocks := []MockRoute{
+			{"PUT", "/v2/organizations/3b6f763f-aae1-4177-9b93-f2de6f2a48f2/private_domains/3b6f763f-aae1-4177-9b93-f2de6f2a48f2", sharePrivateDomainPayload, "", 201, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		domain, err := client.ShareOrgPrivateDomain("3b6f763f-aae1-4177-9b93-f2de6f2a48f2", "3b6f763f-aae1-4177-9b93-f2de6f2a48f2")
+		So(err, ShouldBeNil)
+
+		So(domain.Guid, ShouldEqual, "3b6f763f-aae1-4177-9b93-f2de6f2a48f2")
+
+	})
+}
+
+func TestUnshareOrgPrivateDomain(t *testing.T) {
+	Convey("Unshare Org Private Domain", t, func() {
+		mocks := []MockRoute{
+			{"DELETE", "/v2/organizations/3b6f763f-aae1-4177-9b93-f2de6f2a48f2/private_domains/3b6f763f-aae1-4177-9b93-f2de6f2a48f2", sharePrivateDomainPayload, "", 201, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		err = client.UnshareOrgPrivateDomain("3b6f763f-aae1-4177-9b93-f2de6f2a48f2", "3b6f763f-aae1-4177-9b93-f2de6f2a48f2")
+		So(err, ShouldBeNil)
+
+	})
+}

--- a/orgs_test.go
+++ b/orgs_test.go
@@ -531,3 +531,36 @@ func TestRemoveUserByUsername(t *testing.T) {
 		So(err, ShouldBeNil)
 	})
 }
+
+func TestListOrgSpaceQuotas(t *testing.T) {
+	Convey("List Org Space Quotas", t, func() {
+		mocks := []MockRoute{
+			{"GET", "/v2/organizations/06dcedd4-1f24-49a6-adc1-cce9131a1b2c/space_quota_definitions", listSpaceQuotasPayloadPage1, "", 200, "", nil},
+			{"GET", "/v2/space_quota_definitions_page_2", listSpaceQuotasPayloadPage2, "", 200, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		spaceQuotas, err := client.ListOrgSpaceQuotas("06dcedd4-1f24-49a6-adc1-cce9131a1b2c")
+		So(err, ShouldBeNil)
+
+		So(len(spaceQuotas), ShouldEqual, 2)
+		So(spaceQuotas[0].Guid, ShouldEqual, "889aa2ed-a883-4cc0-abe5-804b2503f15d")
+		So(spaceQuotas[0].Name, ShouldEqual, "test-1")
+		So(spaceQuotas[0].NonBasicServicesAllowed, ShouldEqual, true)
+		So(spaceQuotas[0].TotalServices, ShouldEqual, -1)
+		So(spaceQuotas[0].TotalRoutes, ShouldEqual, 100)
+		So(spaceQuotas[0].MemoryLimit, ShouldEqual, 102400)
+		So(spaceQuotas[0].InstanceMemoryLimit, ShouldEqual, -1)
+		So(spaceQuotas[0].AppInstanceLimit, ShouldEqual, -1)
+		So(spaceQuotas[0].AppTaskLimit, ShouldEqual, -1)
+		So(spaceQuotas[0].TotalServiceKeys, ShouldEqual, -1)
+		So(spaceQuotas[0].TotalReservedRoutePorts, ShouldEqual, -1)
+	})
+}

--- a/orgs_test.go
+++ b/orgs_test.go
@@ -276,7 +276,7 @@ func TestDeleteOrg(t *testing.T) {
 
 func TestAssociateManager(t *testing.T) {
 	Convey("Associate manager", t, func() {
-		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers/user-guid", associateOrgManagerPayload, "", 201, "", nil}, t)
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers/user-guid", associateOrgUserPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -298,7 +298,7 @@ func TestAssociateManager(t *testing.T) {
 
 func TestAssociateAuditor(t *testing.T) {
 	Convey("Associate auditor", t, func() {
-		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors/user-guid", associateOrgAuditorPayload, "", 201, "", nil}, t)
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors/user-guid", associateOrgUserPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -313,6 +313,28 @@ func TestAssociateAuditor(t *testing.T) {
 		}
 
 		newOrg, err := org.AssociateAuditor("user-guid")
+		So(err, ShouldBeNil)
+		So(newOrg.Guid, ShouldEqual, "bc7b4caf-f4b8-4d85-b126-0729b9351e56")
+	})
+}
+
+func TestAssociateBillingManager(t *testing.T) {
+	Convey("Associate billing manager", t, func() {
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/billing_managers/user-guid", associateOrgUserPayload, "", 201, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		org := &Org{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		newOrg, err := org.AssociateBillingManager("user-guid")
 		So(err, ShouldBeNil)
 		So(newOrg.Guid, ShouldEqual, "bc7b4caf-f4b8-4d85-b126-0729b9351e56")
 	})
@@ -342,7 +364,7 @@ func TestAssociateUser(t *testing.T) {
 
 func TestAssociateManagerByUsername(t *testing.T) {
 	Convey("Associate manager by username", t, func() {
-		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers", associateOrgManagerPayload, "", 201, "", nil}, t)
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers", associateOrgUserPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -364,7 +386,7 @@ func TestAssociateManagerByUsername(t *testing.T) {
 
 func TestAssociateAuditorByUsername(t *testing.T) {
 	Convey("Associate auditor by username", t, func() {
-		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", associateOrgAuditorPayload, "", 201, "", nil}, t)
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", associateOrgUserPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -379,6 +401,28 @@ func TestAssociateAuditorByUsername(t *testing.T) {
 		}
 
 		newOrg, err := org.AssociateAuditorByUsername("user-name")
+		So(err, ShouldBeNil)
+		So(newOrg.Guid, ShouldEqual, "bc7b4caf-f4b8-4d85-b126-0729b9351e56")
+	})
+}
+
+func TestAssociateBillingManagerByUsername(t *testing.T) {
+	Convey("Associate billing manager by username", t, func() {
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/billing_managers", associateOrgUserPayload, "", 201, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		org := &Org{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		newOrg, err := org.AssociateBillingManagerByUsername("user-name")
 		So(err, ShouldBeNil)
 		So(newOrg.Guid, ShouldEqual, "bc7b4caf-f4b8-4d85-b126-0729b9351e56")
 	})
@@ -448,6 +492,27 @@ func TestRemoveAuditor(t *testing.T) {
 	})
 }
 
+func TestRemoveBillingManager(t *testing.T) {
+	Convey("Remove billing manager", t, func() {
+		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/billing_managers/user-guid", "", "", 204, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		org := &Org{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		err = org.RemoveBillingManager("user-guid")
+		So(err, ShouldBeNil)
+	})
+}
+
 func TestRemoveUser(t *testing.T) {
 	Convey("Remove user", t, func() {
 		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users/user-guid", "", "", 204, "", nil}, t)
@@ -507,6 +572,27 @@ func TestRemoveAuditorByUsername(t *testing.T) {
 		}
 
 		err = org.RemoveAuditorByUsername("user-name")
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestRemoveBillingManagerByUsername(t *testing.T) {
+	Convey("Remove billing manager by username", t, func() {
+		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/billing_managers", "", "", 204, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		org := &Org{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		err = org.RemoveBillingManagerByUsername("user-name")
 		So(err, ShouldBeNil)
 	})
 }

--- a/orgs_test.go
+++ b/orgs_test.go
@@ -667,3 +667,25 @@ func TestListOrgSpaceQuotas(t *testing.T) {
 		So(spaceQuotas[0].TotalReservedRoutePorts, ShouldEqual, -1)
 	})
 }
+
+func TestListOrgPrivateDomains(t *testing.T) {
+	Convey("List Org Space Quotas", t, func() {
+		mocks := []MockRoute{
+			{"GET", "/v2/organizations/06dcedd4-1f24-49a6-adc1-cce9131a1b2c/private_domains", listDomainsPayload, "", 200, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		privateDomains, err := client.ListOrgPrivateDomains("06dcedd4-1f24-49a6-adc1-cce9131a1b2c")
+		So(err, ShouldBeNil)
+
+		So(len(privateDomains), ShouldEqual, 4)
+
+	})
+}

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -407,56 +407,6 @@ const orgQuotaPayload = `{
    }
 }`
 
-const associateOrgManagerPayload = `{
-  "metadata": {
-    "guid": "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
-    "url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56",
-    "created_at": "2016-06-08T16:41:34Z",
-    "updated_at": "2016-06-08T16:41:26Z"
-  },
-  "entity": {
-    "name": "name-1735",
-    "billing_enabled": false,
-    "quota_definition_guid": "84eed1c7-cc2d-4823-a578-081fef03ba7d",
-    "status": "active",
-    "quota_definition_url": "/v2/quota_definitions/84eed1c7-cc2d-4823-a578-081fef03ba7d",
-    "spaces_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/spaces",
-    "domains_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/domains",
-    "private_domains_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/private_domains",
-    "users_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users",
-    "managers_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers",
-    "billing_managers_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/billing_managers",
-    "auditors_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors",
-    "app_events_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/app_events",
-    "space_quota_definitions_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/space_quota_definitions"
-  }
-}`
-
-const associateOrgAuditorPayload = `{
-  "metadata": {
-    "guid": "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
-    "url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56",
-    "created_at": "2016-06-08T16:41:34Z",
-    "updated_at": "2016-06-08T16:41:26Z"
-  },
-  "entity": {
-    "name": "name-1735",
-    "billing_enabled": false,
-    "quota_definition_guid": "84eed1c7-cc2d-4823-a578-081fef03ba7d",
-    "status": "active",
-    "quota_definition_url": "/v2/quota_definitions/84eed1c7-cc2d-4823-a578-081fef03ba7d",
-    "spaces_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/spaces",
-    "domains_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/domains",
-    "private_domains_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/private_domains",
-    "users_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users",
-    "managers_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers",
-    "billing_managers_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/billing_managers",
-    "auditors_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors",
-    "app_events_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/app_events",
-    "space_quota_definitions_url": "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/space_quota_definitions"
-  }
-}`
-
 const associateOrgUserPayload = `{
   "metadata": {
     "guid": "bc7b4caf-f4b8-4d85-b126-0729b9351e56",

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -742,33 +742,7 @@ const spaceByGuidPayload = `{
   }
 }`
 
-const associateSpaceAuditorPayload = `{
-  "metadata": {
-    "guid": "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
-    "url": "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56",
-    "created_at": "2016-06-08T16:41:34Z",
-    "updated_at": "2016-06-08T16:41:26Z"
-  },
-  "entity": {
-    "name": "name-1735",
-    "organization_guid": "227161e2-667b-483f-9821-77257a38997f",
-    "space_quota_definition_guid": null,
-    "allow_ssh": true,
-    "organization_url": "/v2/organizations/227161e2-667b-483f-9821-77257a38997f",
-    "developers_url": "/v2/spaces/20e7a265-f50d-4c14-ac7e-42c52f9d9cd7/developers",
-    "managers_url": "/v2/spaces/20e7a265-f50d-4c14-ac7e-42c52f9d9cd7/managers",
-    "auditors_url": "/v2/spaces/20e7a265-f50d-4c14-ac7e-42c52f9d9cd7/auditors",
-    "apps_url": "/v2/spaces/20e7a265-f50d-4c14-ac7e-42c52f9d9cd7/apps",
-    "routes_url": "/v2/spaces/20e7a265-f50d-4c14-ac7e-42c52f9d9cd7/routes",
-    "domains_url": "/v2/spaces/20e7a265-f50d-4c14-ac7e-42c52f9d9cd7/domains",
-    "service_instances_url": "/v2/spaces/20e7a265-f50d-4c14-ac7e-42c52f9d9cd7/service_instances",
-    "app_events_url": "/v2/spaces/20e7a265-f50d-4c14-ac7e-42c52f9d9cd7/app_events",
-    "events_url": "/v2/spaces/20e7a265-f50d-4c14-ac7e-42c52f9d9cd7/events",
-    "security_groups_url": "/v2/spaces/20e7a265-f50d-4c14-ac7e-42c52f9d9cd7/security_groups"
-   }
-}`
-
-const associateSpaceDeveloperPayload = `{
+const associateSpaceUserPayload = `{
   "metadata": {
     "guid": "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
     "url": "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56",

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -3302,3 +3302,29 @@ const listServiceUsageEventsPayloadPage2 = `
     }
   ]
 }`
+
+const sharePrivateDomainPayload = `{
+  "metadata": {
+    "guid": "3b6f763f-aae1-4177-9b93-f2de6f2a48f2",
+    "url": "/v2/organizations/3b6f763f-aae1-4177-9b93-f2de6f2a48f2",
+    "created_at": "2016-06-08T16:41:35Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "name-1777",
+    "billing_enabled": false,
+    "quota_definition_guid": "8737180b-8587-4244-a37d-a12bffcc24b5",
+    "status": "active",
+    "quota_definition_url": "/v2/quota_definitions/8737180b-8587-4244-a37d-a12bffcc24b5",
+    "spaces_url": "/v2/organizations/3b6f763f-aae1-4177-9b93-f2de6f2a48f2/spaces",
+    "domains_url": "/v2/organizations/3b6f763f-aae1-4177-9b93-f2de6f2a48f2/domains",
+    "private_domains_url": "/v2/organizations/3b6f763f-aae1-4177-9b93-f2de6f2a48f2/private_domains",
+    "users_url": "/v2/organizations/3b6f763f-aae1-4177-9b93-f2de6f2a48f2/users",
+    "managers_url": "/v2/organizations/3b6f763f-aae1-4177-9b93-f2de6f2a48f2/managers",
+    "billing_managers_url": "/v2/organizations/3b6f763f-aae1-4177-9b93-f2de6f2a48f2/billing_managers",
+    "auditors_url": "/v2/organizations/3b6f763f-aae1-4177-9b93-f2de6f2a48f2/auditors",
+    "app_events_url": "/v2/organizations/3b6f763f-aae1-4177-9b93-f2de6f2a48f2/app_events",
+    "space_quota_definitions_url": "/v2/organizations/3b6f763f-aae1-4177-9b93-f2de6f2a48f2/space_quota_definitions"
+  }
+}
+`

--- a/secgroups.go
+++ b/secgroups.go
@@ -336,11 +336,15 @@ func (c *Client) secGroupCreateHelper(url, method, name string, rules []SecGroup
 
 	req := c.NewRequest(method, url)
 	//set up request body
-	req.obj = map[string]interface{}{
-		"name":        name,
-		"rules":       reqRules,
-		"space_guids": spaceGuids,
+	inputs := map[string]interface{}{
+		"name":  name,
+		"rules": reqRules,
 	}
+
+	if spaceGuids != nil {
+		inputs["space_guids"] = spaceGuids
+	}
+	req.obj = inputs
 	//fire off the request and check for problems
 	resp, err := c.DoRequest(req)
 	if err != nil {

--- a/secgroups.go
+++ b/secgroups.go
@@ -239,7 +239,7 @@ UnbindRunningSecGroup contacts the CF endpoint to dis-associate  a security grou
 secGUID: identifies the security group to add a space to
 */
 func (c *Client) UnbindRunningSecGroup(secGUID string) error {
-	//Perform the PUT and check for errors
+	//Perform the DELETE and check for errors
 	resp, err := c.DoRequest(c.NewRequest("DELETE", fmt.Sprintf("/v2/config/running_security_groups/%s", secGUID)))
 	if err != nil {
 		return err
@@ -271,7 +271,7 @@ UnbindStagingSecGroup contacts the CF endpoint to dis-associate a space with a s
 secGUID: identifies the security group to add a space to
 */
 func (c *Client) UnbindStagingSecGroup(secGUID string) error {
-	//Perform the PUT and check for errors
+	//Perform the DELETE and check for errors
 	resp, err := c.DoRequest(c.NewRequest("DELETE", fmt.Sprintf("/v2/config/staging_security_groups/%s", secGUID)))
 	if err != nil {
 		return err

--- a/secgroups.go
+++ b/secgroups.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"reflect"
 	"strings"
 
@@ -234,6 +235,22 @@ func (c *Client) BindRunningSecGroup(secGUID string) error {
 }
 
 /*
+UnbindRunningSecGroup contacts the CF endpoint to dis-associate  a security group
+secGUID: identifies the security group to add a space to
+*/
+func (c *Client) UnbindRunningSecGroup(secGUID string) error {
+	//Perform the PUT and check for errors
+	resp, err := c.DoRequest(c.NewRequest("DELETE", fmt.Sprintf("/v2/config/running_security_groups/%s", secGUID)))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusNoContent { //204
+		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
+	}
+	return nil
+}
+
+/*
 BindStagingSecGroup contacts the CF endpoint to associate a space with a security group
 secGUID: identifies the security group to add a space to
 */
@@ -244,6 +261,22 @@ func (c *Client) BindStagingSecGroup(secGUID string) error {
 		return err
 	}
 	if resp.StatusCode != 200 { //200
+		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
+	}
+	return nil
+}
+
+/*
+UnbindStagingSecGroup contacts the CF endpoint to dis-associate a space with a security group
+secGUID: identifies the security group to add a space to
+*/
+func (c *Client) UnbindStagingSecGroup(secGUID string) error {
+	//Perform the PUT and check for errors
+	resp, err := c.DoRequest(c.NewRequest("DELETE", fmt.Sprintf("/v2/config/staging_security_groups/%s", secGUID)))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusNoContent { //204
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil

--- a/secgroups_test.go
+++ b/secgroups_test.go
@@ -92,3 +92,79 @@ func TestSecGroupListSpaceResources(t *testing.T) {
 		So(spaces[3].Entity.Name, ShouldEqual, "prod")
 	})
 }
+
+func TestBindRunningSecGroups(t *testing.T) {
+	Convey("Unbind Running Sec Groups", t, func() {
+		mocks := []MockRoute{
+			{"PUT", "/v2/config/running_security_groups/8efd7c5c-d83c-4786-b399-b7bd548839e1", "", "", 200, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		err = client.BindRunningSecGroup("8efd7c5c-d83c-4786-b399-b7bd548839e1")
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestUnbindRunningSecGroups(t *testing.T) {
+	Convey("Unbind Running Sec Groups", t, func() {
+		mocks := []MockRoute{
+			{"DELETE", "/v2/config/running_security_groups/8efd7c5c-d83c-4786-b399-b7bd548839e1", "", "", 204, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		err = client.UnbindRunningSecGroup("8efd7c5c-d83c-4786-b399-b7bd548839e1")
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestBindStagingSecGroups(t *testing.T) {
+	Convey("Unbind Staging Sec Groups", t, func() {
+		mocks := []MockRoute{
+			{"PUT", "/v2/config/staging_security_groups/8efd7c5c-d83c-4786-b399-b7bd548839e1", "", "", 200, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		err = client.BindStagingSecGroup("8efd7c5c-d83c-4786-b399-b7bd548839e1")
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestUnbindStagingSecGroups(t *testing.T) {
+	Convey("Unbind Staging Sec Groups", t, func() {
+		mocks := []MockRoute{
+			{"DELETE", "/v2/config/staging_security_groups/8efd7c5c-d83c-4786-b399-b7bd548839e1", "", "", 204, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		err = client.UnbindStagingSecGroup("8efd7c5c-d83c-4786-b399-b7bd548839e1")
+		So(err, ShouldBeNil)
+	})
+}

--- a/space_quotas.go
+++ b/space_quotas.go
@@ -112,58 +112,58 @@ func (c *Client) getSpaceQuotasResponse(requestUrl string) (SpaceQuotasResponse,
 	return spaceQuotasResp, nil
 }
 
-func (c *Client) CreateSpaceQuota(spaceQuote SpaceQuotaRequest) (SpaceQuota, error) {
+func (c *Client) CreateSpaceQuota(spaceQuote SpaceQuotaRequest) (*SpaceQuota, error) {
 	buf := bytes.NewBuffer(nil)
 	err := json.NewEncoder(buf).Encode(spaceQuote)
 	if err != nil {
-		return SpaceQuota{}, err
+		return nil, err
 	}
 	r := c.NewRequestWithBody("POST", "/v2/space_quota_definitions", buf)
 	resp, err := c.DoRequest(r)
 	if err != nil {
-		return SpaceQuota{}, err
+		return nil, err
 	}
 	if resp.StatusCode != http.StatusCreated {
-		return SpaceQuota{}, fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
+		return nil, fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return c.handleSpaceQuotaResp(resp)
 }
 
-func (c *Client) UpdateSpaceQuota(spaceQuotaGUID string, spaceQuote SpaceQuotaRequest) (SpaceQuota, error) {
+func (c *Client) UpdateSpaceQuota(spaceQuotaGUID string, spaceQuote SpaceQuotaRequest) (*SpaceQuota, error) {
 	buf := bytes.NewBuffer(nil)
 	err := json.NewEncoder(buf).Encode(spaceQuote)
 	if err != nil {
-		return SpaceQuota{}, err
+		return nil, err
 	}
 	r := c.NewRequestWithBody("PUT", fmt.Sprintf("/v2/space_quota_definitions/%s", spaceQuotaGUID), buf)
 	resp, err := c.DoRequest(r)
 	if err != nil {
-		return SpaceQuota{}, err
+		return nil, err
 	}
 	if resp.StatusCode != http.StatusCreated {
-		return SpaceQuota{}, fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
+		return nil, fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return c.handleSpaceQuotaResp(resp)
 }
 
-func (c *Client) handleSpaceQuotaResp(resp *http.Response) (SpaceQuota, error) {
+func (c *Client) handleSpaceQuotaResp(resp *http.Response) (*SpaceQuota, error) {
 	body, err := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
-		return SpaceQuota{}, err
+		return nil, err
 	}
 	var spaceQuotasResource SpaceQuotasResource
 	err = json.Unmarshal(body, &spaceQuotasResource)
 	if err != nil {
-		return SpaceQuota{}, err
+		return nil, err
 	}
 	return c.mergeSpaceQuotaResource(spaceQuotasResource), nil
 }
 
-func (c *Client) mergeSpaceQuotaResource(spaceQuote SpaceQuotasResource) SpaceQuota {
+func (c *Client) mergeSpaceQuotaResource(spaceQuote SpaceQuotasResource) *SpaceQuota {
 	spaceQuote.Entity.Guid = spaceQuote.Meta.Guid
 	spaceQuote.Entity.CreatedAt = spaceQuote.Meta.CreatedAt
 	spaceQuote.Entity.UpdatedAt = spaceQuote.Meta.UpdatedAt
 	spaceQuote.Entity.c = c
-	return spaceQuote.Entity
+	return &spaceQuote.Entity
 }

--- a/space_quotas.go
+++ b/space_quotas.go
@@ -112,6 +112,18 @@ func (c *Client) getSpaceQuotasResponse(requestUrl string) (SpaceQuotasResponse,
 	return spaceQuotasResp, nil
 }
 
+func (c *Client) AssignSpaceQuota(quotaGUID, spaceGUID string) error {
+	//Perform the PUT and check for errors
+	resp, err := c.DoRequest(c.NewRequest("PUT", fmt.Sprintf("/v2/space_quota_definitions/%s/spaces/%s", quotaGUID, spaceGUID)))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusCreated { //201
+		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
+	}
+	return nil
+}
+
 func (c *Client) CreateSpaceQuota(spaceQuote SpaceQuotaRequest) (*SpaceQuota, error) {
 	buf := bytes.NewBuffer(nil)
 	err := json.NewEncoder(buf).Encode(spaceQuote)

--- a/space_quotas.go
+++ b/space_quotas.go
@@ -1,9 +1,11 @@
 package cfclient
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 
 	"github.com/pkg/errors"
@@ -21,8 +23,24 @@ type SpaceQuotasResource struct {
 	Entity SpaceQuota `json:"entity"`
 }
 
+type SpaceQuotaRequest struct {
+	Name                    string `json:"name"`
+	OrganizationGuid        string `json:"organization_guid"`
+	NonBasicServicesAllowed bool   `json:"non_basic_services_allowed"`
+	TotalServices           int    `json:"total_services"`
+	TotalRoutes             int    `json:"total_routes"`
+	MemoryLimit             int    `json:"memory_limit"`
+	InstanceMemoryLimit     int    `json:"instance_memory_limit"`
+	AppInstanceLimit        int    `json:"app_instance_limit"`
+	AppTaskLimit            int    `json:"app_task_limit"`
+	TotalServiceKeys        int    `json:"total_service_keys"`
+	TotalReservedRoutePorts int    `json:"total_reserved_route_ports"`
+}
+
 type SpaceQuota struct {
 	Guid                    string `json:"guid"`
+	CreatedAt               string `json:"created_at,omitempty"`
+	UpdatedAt               string `json:"updated_at,omitempty"`
 	Name                    string `json:"name"`
 	OrganizationGuid        string `json:"organization_guid"`
 	NonBasicServicesAllowed bool   `json:"non_basic_services_allowed"`
@@ -92,4 +110,60 @@ func (c *Client) getSpaceQuotasResponse(requestUrl string) (SpaceQuotasResponse,
 		return SpaceQuotasResponse{}, errors.Wrap(err, "Error unmarshalling space quotas")
 	}
 	return spaceQuotasResp, nil
+}
+
+func (c *Client) CreateSpaceQuota(spaceQuote SpaceQuotaRequest) (SpaceQuota, error) {
+	buf := bytes.NewBuffer(nil)
+	err := json.NewEncoder(buf).Encode(spaceQuote)
+	if err != nil {
+		return SpaceQuota{}, err
+	}
+	r := c.NewRequestWithBody("POST", "/v2/space_quota_definitions", buf)
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return SpaceQuota{}, err
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return SpaceQuota{}, fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
+	}
+	return c.handleSpaceQuotaResp(resp)
+}
+
+func (c *Client) UpdateSpaceQuota(spaceQuotaGUID string, spaceQuote SpaceQuotaRequest) (SpaceQuota, error) {
+	buf := bytes.NewBuffer(nil)
+	err := json.NewEncoder(buf).Encode(spaceQuote)
+	if err != nil {
+		return SpaceQuota{}, err
+	}
+	r := c.NewRequestWithBody("PUT", fmt.Sprintf("/v2/space_quota_definitions/%s", spaceQuotaGUID), buf)
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return SpaceQuota{}, err
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return SpaceQuota{}, fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
+	}
+	return c.handleSpaceQuotaResp(resp)
+}
+
+func (c *Client) handleSpaceQuotaResp(resp *http.Response) (SpaceQuota, error) {
+	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return SpaceQuota{}, err
+	}
+	var spaceQuotasResource SpaceQuotasResource
+	err = json.Unmarshal(body, &spaceQuotasResource)
+	if err != nil {
+		return SpaceQuota{}, err
+	}
+	return c.mergeSpaceQuotaResource(spaceQuotasResource), nil
+}
+
+func (c *Client) mergeSpaceQuotaResource(spaceQuote SpaceQuotasResource) SpaceQuota {
+	spaceQuote.Entity.Guid = spaceQuote.Meta.Guid
+	spaceQuote.Entity.CreatedAt = spaceQuote.Meta.CreatedAt
+	spaceQuote.Entity.UpdatedAt = spaceQuote.Meta.UpdatedAt
+	spaceQuote.Entity.c = c
+	return spaceQuote.Entity
 }

--- a/space_quotas_test.go
+++ b/space_quotas_test.go
@@ -116,3 +116,20 @@ func TestUpdateSpaceQuota(t *testing.T) {
 
 	})
 }
+
+
+func TestAssignSpaceQuota(t *testing.T) {
+	Convey("Assign Space Quota", t, func() {
+		setup(MockRoute{"PUT", "/v2/space_quota_definitions/9ffd7c5c-d83c-4786-b399-b7bd54883977/spaces/8efd7c5c-d83c-4786-b399-b7bd548839e1", "", "", 201, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		err = client.AssignSpaceQuota("9ffd7c5c-d83c-4786-b399-b7bd54883977", "8efd7c5c-d83c-4786-b399-b7bd548839e1")
+		So(err, ShouldBeNil)
+	})
+}

--- a/space_quotas_test.go
+++ b/space_quotas_test.go
@@ -66,3 +66,53 @@ func TestGetSpaceQuotaByName(t *testing.T) {
 		So(spaceQuota.TotalReservedRoutePorts, ShouldEqual, 80)
 	})
 }
+
+func TestCreateSpaceQuota(t *testing.T) {
+	Convey("Create Space Quota", t, func() {
+		setup(MockRoute{"POST", "/v2/space_quota_definitions", spaceQuotaPayload, "", 201, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		spaceQuotaRequest := SpaceQuotaRequest{
+			Name: "test-2",
+			OrganizationGuid: "06dcedd4-1f24-49a6-adc1-cce9131a1b2c",
+		}
+
+		spaceQuota, err := client.CreateSpaceQuota(spaceQuotaRequest)
+		So(err, ShouldBeNil)
+
+		So(spaceQuota.Name, ShouldEqual, "test-2")
+		So(spaceQuota.OrganizationGuid, ShouldEqual, "06dcedd4-1f24-49a6-adc1-cce9131a1b2c")
+
+	})
+}
+
+func TestUpdateSpaceQuota(t *testing.T) {
+	Convey("Create Update Quota", t, func() {
+		setup(MockRoute{"PUT", "/v2/space_quota_definitions/9ffd7c5c-d83c-4786-b399-b7bd54883977", spaceQuotaPayload, "", 201, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		spaceQuotaRequest := SpaceQuotaRequest{
+			Name: "test-2",
+			OrganizationGuid: "06dcedd4-1f24-49a6-adc1-cce9131a1b2c",
+		}
+
+		spaceQuota, err := client.UpdateSpaceQuota("9ffd7c5c-d83c-4786-b399-b7bd54883977", spaceQuotaRequest)
+		So(err, ShouldBeNil)
+
+		So(spaceQuota.Name, ShouldEqual, "test-2")
+		So(spaceQuota.OrganizationGuid, ShouldEqual, "06dcedd4-1f24-49a6-adc1-cce9131a1b2c")
+
+	})
+}

--- a/spaces.go
+++ b/spaces.go
@@ -83,16 +83,17 @@ type SpaceUserResponse struct {
 }
 
 type Space struct {
-	Guid                string      `json:"guid"`
-	CreatedAt           string      `json:"created_at"`
-	UpdatedAt           string      `json:"updated_at"`
-	Name                string      `json:"name"`
-	OrganizationGuid    string      `json:"organization_guid"`
-	OrgURL              string      `json:"organization_url"`
-	OrgData             OrgResource `json:"organization"`
-	QuotaDefinitionGuid string      `json:"space_quota_definition_guid"`
-	AllowSSH            bool        `json:"allow_ssh"`
-	c                   *Client
+	Guid                 string      `json:"guid"`
+	CreatedAt            string      `json:"created_at"`
+	UpdatedAt            string      `json:"updated_at"`
+	Name                 string      `json:"name"`
+	OrganizationGuid     string      `json:"organization_guid"`
+	OrgURL               string      `json:"organization_url"`
+	OrgData              OrgResource `json:"organization"`
+	QuotaDefinitionGuid  string      `json:"space_quota_definition_guid"`
+	IsolationSegmentGuid string      `json:"isolation_segment_guid"`
+	AllowSSH             bool        `json:"allow_ssh"`
+	c                    *Client
 }
 
 type SpaceSummary struct {

--- a/spaces.go
+++ b/spaces.go
@@ -12,16 +12,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-type UpdateSpaceRequest struct {
-	DeveloperGuid      []string `json:"developer_guids,omitempty"`
-	ManagerGuid        []string `json:"manager_guids,omitempty"`
-	AuditorGuid        []string `json:"auditor_guids,omitempty"`
-	DomainGuid         []string `json:"domain_guids,omitempty"`
-	SecurityGroupGuids []string `json:"security_group_guids,omitempty"`
-	SpaceQuotaDefGuid  string   `json:"space_quota_definition_guid,omitempty"`
-	AllowSSH           bool     `json:"allow_ssh,omitempty"`
-}
-
 type SpaceRequest struct {
 	Name               string   `json:"name"`
 	OrganizationGuid   string   `json:"organization_guid"`
@@ -245,7 +235,7 @@ func (c *Client) CreateSpace(req SpaceRequest) (Space, error) {
 	return c.handleSpaceResp(resp)
 }
 
-func (c *Client) UpdateSpace(spaceGUID string, req UpdateSpaceRequest) (Space, error) {
+func (c *Client) UpdateSpace(spaceGUID string, req SpaceRequest) (Space, error) {
 	space := Space{Guid: spaceGUID, c: c}
 	return space.Update(req)
 }
@@ -466,7 +456,7 @@ func (s *Space) GetServiceOfferings() (ServiceOfferingResponse, error) {
 	return response, nil
 }
 
-func (s *Space) Update(req UpdateSpaceRequest) (Space, error) {
+func (s *Space) Update(req SpaceRequest) (Space, error) {
 	buf := bytes.NewBuffer(nil)
 	err := json.NewEncoder(buf).Encode(req)
 	if err != nil {

--- a/spaces.go
+++ b/spaces.go
@@ -12,6 +12,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+type UpdateSpaceRequest struct {
+	DeveloperGuid      []string `json:"developer_guids,omitempty"`
+	ManagerGuid        []string `json:"manager_guids,omitempty"`
+	AuditorGuid        []string `json:"auditor_guids,omitempty"`
+	DomainGuid         []string `json:"domain_guids,omitempty"`
+	SecurityGroupGuids []string `json:"security_group_guids,omitempty"`
+	SpaceQuotaDefGuid  string   `json:"space_quota_definition_guid,omitempty"`
+	AllowSSH           bool     `json:"allow_ssh,omitempty"`
+}
+
 type SpaceRequest struct {
 	Name               string   `json:"name"`
 	OrganizationGuid   string   `json:"organization_guid"`
@@ -235,7 +245,7 @@ func (c *Client) CreateSpace(req SpaceRequest) (Space, error) {
 	return c.handleSpaceResp(resp)
 }
 
-func (c *Client) UpdateSpace(spaceGUID string, req SpaceRequest) (Space, error) {
+func (c *Client) UpdateSpace(spaceGUID string, req UpdateSpaceRequest) (Space, error) {
 	space := Space{Guid: spaceGUID, c: c}
 	return space.Update(req)
 }
@@ -406,7 +416,7 @@ func (s *Space) GetServiceOfferings() (ServiceOfferingResponse, error) {
 	return response, nil
 }
 
-func (s *Space) Update(req SpaceRequest) (Space, error) {
+func (s *Space) Update(req UpdateSpaceRequest) (Space, error) {
 	buf := bytes.NewBuffer(nil)
 	err := json.NewEncoder(buf).Encode(req)
 	if err != nil {

--- a/spaces_test.go
+++ b/spaces_test.go
@@ -137,9 +137,9 @@ func TestUpdateSpace(t *testing.T) {
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 
-		spaceRequest := SpaceRequest{Name: "test-space", OrganizationGuid: "da0dba14-6064-4f7a-b15a-ff9e677e49b2", AllowSSH: false}
+		updateSpaceRequest := UpdateSpaceRequest{AllowSSH: false}
 
-		space, err := client.UpdateSpace("a72fa1e8-c694-47b3-85f2-55f61fd00d73",spaceRequest)
+		space, err := client.UpdateSpace("a72fa1e8-c694-47b3-85f2-55f61fd00d73",updateSpaceRequest)
 		So(err, ShouldBeNil)
 
 		So(space.Guid, ShouldEqual, "a72fa1e8-c694-47b3-85f2-55f61fd00d73")

--- a/spaces_test.go
+++ b/spaces_test.go
@@ -291,7 +291,7 @@ func TestSpaceRoles(t *testing.T) {
 
 func TestAssociateSpaceAuditorByUsername(t *testing.T) {
 	Convey("Associate auditor by username", t, func() {
-		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", associateSpaceAuditorPayload, "", 201, "", nil}, t)
+		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", associateSpaceUserPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -313,7 +313,7 @@ func TestAssociateSpaceAuditorByUsername(t *testing.T) {
 
 func TestAssociateSpaceDeveloperByUsername(t *testing.T) {
 	Convey("Associate developer by username", t, func() {
-		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/developers", associateSpaceDeveloperPayload, "", 201, "", nil}, t)
+		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/developers", associateSpaceUserPayload, "", 201, "", nil}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -328,6 +328,28 @@ func TestAssociateSpaceDeveloperByUsername(t *testing.T) {
 		}
 
 		newSpace, err := space.AssociateDeveloperByUsername("user-name")
+		So(err, ShouldBeNil)
+		So(newSpace.Guid, ShouldEqual, "bc7b4caf-f4b8-4d85-b126-0729b9351e56")
+	})
+}
+
+func TestAssociateSpaceManagerByUsername(t *testing.T) {
+	Convey("Associate manager by username", t, func() {
+		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers", associateSpaceUserPayload, "", 201, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		space := &Space{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		newSpace, err := space.AssociateManagerByUsername("user-name")
 		So(err, ShouldBeNil)
 		So(newSpace.Guid, ShouldEqual, "bc7b4caf-f4b8-4d85-b126-0729b9351e56")
 	})
@@ -370,6 +392,27 @@ func TestRemoveSpaceAuditorByUsername(t *testing.T) {
 		}
 
 		err = space.RemoveAuditorByUsername("user-name")
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestRemoveSpaceManagerByUsername(t *testing.T) {
+	Convey("Remove manager by username", t, func() {
+		setup(MockRoute{"DELETE", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers", "", "", 200, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		space := &Space{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		err = space.RemoveManagerByUsername("user-name")
 		So(err, ShouldBeNil)
 	})
 }

--- a/spaces_test.go
+++ b/spaces_test.go
@@ -126,6 +126,29 @@ func TestCreateSpace(t *testing.T) {
 	})
 }
 
+func TestUpdateSpace(t *testing.T) {
+	Convey("Update Space", t, func() {
+		setup(MockRoute{"PUT", "/v2/spaces/a72fa1e8-c694-47b3-85f2-55f61fd00d73", spacePayload, "", 201, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		spaceRequest := SpaceRequest{Name: "test-space", OrganizationGuid: "da0dba14-6064-4f7a-b15a-ff9e677e49b2", AllowSSH: false}
+
+		space, err := client.UpdateSpace("a72fa1e8-c694-47b3-85f2-55f61fd00d73",spaceRequest)
+		So(err, ShouldBeNil)
+
+		So(space.Guid, ShouldEqual, "a72fa1e8-c694-47b3-85f2-55f61fd00d73")
+		So(space.Name, ShouldEqual, "test-space")
+		So(space.OrganizationGuid, ShouldEqual, "da0dba14-6064-4f7a-b15a-ff9e677e49b2")
+		So(space.AllowSSH, ShouldEqual, false)
+	})
+}
+
 func TestDeleteSpace(t *testing.T) {
 	Convey("Delete space", t, func() {
 		setup(MockRoute{"DELETE", "/v2/spaces/a537761f-9d93-4b30-af17-3d73dbca181b", "", "", 204, "recursive=false&async=false", nil}, t)

--- a/spaces_test.go
+++ b/spaces_test.go
@@ -186,7 +186,10 @@ func TestUpdateSpace(t *testing.T) {
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 
-		updateSpaceRequest := UpdateSpaceRequest{AllowSSH: false}
+		updateSpaceRequest := SpaceRequest{
+			Name: "test-space",
+			AllowSSH: false,
+		}
 
 		space, err := client.UpdateSpace("a72fa1e8-c694-47b3-85f2-55f61fd00d73",updateSpaceRequest)
 		So(err, ShouldBeNil)

--- a/spaces_test.go
+++ b/spaces_test.go
@@ -48,7 +48,56 @@ func TestListSpaces(t *testing.T) {
 		So(spaces[3].OrganizationGuid, ShouldEqual, "da0dba14-6064-4f7a-b15a-ff9e677e49b2")
 	})
 }
+func TestListSpaceSecGroups(t *testing.T) {
+	Convey("List Space SecGroups", t, func() {
+		mocks := []MockRoute{
+			{"GET", "/v2/spaces/8efd7c5c-d83c-4786-b399-b7bd548839e1/security_groups", listSecGroupsPayload, "", 200, "inline-relations-depth=1", nil},
+			{"GET", "/v2/security_groupsPage2", listSecGroupsPayloadPage2, "", 200, "", nil},
+			{"GET", "/v2/security_groups/af15c29a-6bde-4a9b-8cdf-43aa0d4b7e3c/spaces", emptyResources, "", 200, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
 
+		secGroups, err := client.ListSpaceSecGroups("8efd7c5c-d83c-4786-b399-b7bd548839e1")
+		So(err, ShouldBeNil)
+
+		So(len(secGroups), ShouldEqual, 2)
+		So(secGroups[0].Guid, ShouldEqual, "af15c29a-6bde-4a9b-8cdf-43aa0d4b7e3c")
+		So(secGroups[0].Name, ShouldEqual, "secgroup-test")
+		So(secGroups[0].Running, ShouldEqual, true)
+		So(secGroups[0].Staging, ShouldEqual, true)
+		So(secGroups[0].Rules[0].Protocol, ShouldEqual, "tcp")
+		So(secGroups[0].Rules[0].Ports, ShouldEqual, "443,4443")
+		So(secGroups[0].Rules[0].Destination, ShouldEqual, "1.1.1.1")
+		So(secGroups[0].Rules[1].Protocol, ShouldEqual, "udp")
+		So(secGroups[0].Rules[1].Ports, ShouldEqual, "1111")
+		So(secGroups[0].Rules[1].Destination, ShouldEqual, "1.2.3.4")
+		So(secGroups[0].SpacesURL, ShouldEqual, "/v2/security_groups/af15c29a-6bde-4a9b-8cdf-43aa0d4b7e3c/spaces")
+		So(secGroups[0].SpacesData, ShouldBeEmpty)
+		So(secGroups[1].Guid, ShouldEqual, "f9ad202b-76dd-44ec-b7c2-fd2417a561e8")
+		So(secGroups[1].Name, ShouldEqual, "secgroup-test2")
+		So(secGroups[1].Running, ShouldEqual, false)
+		So(secGroups[1].Staging, ShouldEqual, false)
+		So(secGroups[1].Rules[0].Protocol, ShouldEqual, "udp")
+		So(secGroups[1].Rules[0].Ports, ShouldEqual, "2222")
+		So(secGroups[1].Rules[0].Destination, ShouldEqual, "2.2.2.2")
+		So(secGroups[1].Rules[1].Protocol, ShouldEqual, "tcp")
+		So(secGroups[1].Rules[1].Ports, ShouldEqual, "443,4443")
+		So(secGroups[1].Rules[1].Destination, ShouldEqual, "4.3.2.1")
+		So(secGroups[1].SpacesData[0].Entity.Guid, ShouldEqual, "e0a0d1bf-ad74-4b3c-8f4a-0c33859a54e4")
+		So(secGroups[1].SpacesData[0].Entity.Name, ShouldEqual, "space-test")
+		So(secGroups[1].SpacesData[1].Entity.Guid, ShouldEqual, "a2a0d1bf-ad74-4b3c-8f4a-0c33859a5333")
+		So(secGroups[1].SpacesData[1].Entity.Name, ShouldEqual, "space-test2")
+		So(secGroups[1].SpacesData[2].Entity.Guid, ShouldEqual, "c7a0d1bf-ad74-4b3c-8f4a-0c33859adsa1")
+		So(secGroups[1].SpacesData[2].Entity.Name, ShouldEqual, "space-test3")
+	})
+}
 func TestListSpaceManagers(t *testing.T) {
 	Convey("ListSpaceManagers()", t, func() {
 		setup(MockRoute{"GET", "/v2/spaces/foo/managers", listSpacePeoplePayload, "", 200, "", nil}, t)


### PR DESCRIPTION
Sorry in advance for such a large PR, but added features I needed to have to replace existing approach for interacting with cloud controller.

- associate space managers by username
- update space
- update org
- list security groups for a space
- unbind running and staging security groups
- create/update space quotas
- adding support to associate quota with a space
- create/update org quotas
- list org private domains
- add/remove org billing managers
- share/unshare existing org private domain with other orgs
- adding isolation_segment_guid to returned space struct