### PR TITLE
Improve HTTP error handling

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -90,6 +90,30 @@ func TestMakeRequestWithTimeout(t *testing.T) {
 	})
 }
 
+func TestHTTPErrorHandling(t *testing.T) {
+	Convey("Test making request b", t, func() {
+		setup(MockRoute{"GET", "/v2/organizations", "502 Bad Gateway", "", 502, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress:        server.URL,
+			Username:          "foo",
+			Password:          "bar",
+			SkipSslValidation: true,
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+		req := client.NewRequest("GET", "/v2/organizations")
+		resp, err := client.DoRequest(req)
+		So(err, ShouldNotBeNil)
+		So(resp, ShouldNotBeNil)
+
+		httpErr := err.(CloudFoundryHTTPError)
+		So(httpErr.StatusCode, ShouldEqual, 502)
+		So(httpErr.Status, ShouldEqual, "502 Bad Gateway")
+		So(string(httpErr.Body), ShouldEqual, "502 Bad Gateway")
+	})
+}
+
 func TestTokenRefresh(t *testing.T) {
 	gomega.RegisterTestingT(t)
 	Convey("Test making request", t, func() {

--- a/error.go
+++ b/error.go
@@ -2,7 +2,9 @@ package cfclient
 
 //go:generate go run gen_error.go
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type CloudFoundryErrors struct {
 	Errors []CloudFoundryError `json:"errors"`
@@ -26,4 +28,14 @@ type CloudFoundryError struct {
 
 func (cfErr CloudFoundryError) Error() string {
 	return fmt.Sprintf("cfclient: error (%d): %s", cfErr.Code, cfErr.ErrorCode)
+}
+
+type CloudFoundryHTTPError struct {
+	StatusCode int
+	Status     string
+	Body       []byte
+}
+
+func (e CloudFoundryHTTPError) Error() string {
+	return fmt.Sprintf("cfclient: HTTP error (%d): %s", e.StatusCode, e.Status)
 }


### PR DESCRIPTION
If the response body is not a CF error, the error returned is not
helpful at all because it contains "Could not decode json body".
This is for example the case when the CF API is down for some reason
(e.g. during Backup).

This change adds an own error type for this case, which contains the
necessary bits of the HTTP response.

Let me know if you would like to have something changed. I'll be testing this change in an application today but thought I'd submit it anyway already.