### PR TITLE
Add `created_at` and `updated_at` to ListServicePlansByQuery and ListServicesByQuery

### DIFF
--- a/service_plans.go
+++ b/service_plans.go
@@ -23,6 +23,8 @@ type ServicePlanResource struct {
 type ServicePlan struct {
 	Name                string      `json:"name"`
 	Guid                string      `json:"guid"`
+	CreatedAt           string      `json:"created_at"`
+	UpdatedAt           string      `json:"updated_at"`
 	Free                bool        `json:"free"`
 	Description         string      `json:"description"`
 	ServiceGuid         string      `json:"service_guid"`
@@ -56,6 +58,8 @@ func (c *Client) ListServicePlansByQuery(query url.Values) ([]ServicePlan, error
 		}
 		for _, servicePlan := range servicePlansResp.Resources {
 			servicePlan.Entity.Guid = servicePlan.Meta.Guid
+			servicePlan.Entity.CreatedAt = servicePlan.Meta.CreatedAt
+			servicePlan.Entity.UpdatedAt = servicePlan.Meta.UpdatedAt
 			servicePlan.Entity.c = c
 			servicePlans = append(servicePlans, servicePlan.Entity)
 		}

--- a/service_plans_test.go
+++ b/service_plans_test.go
@@ -23,6 +23,8 @@ func TestListServicePlans(t *testing.T) {
 		So(len(servicePlans), ShouldEqual, 1)
 		So(servicePlans[0].Guid, ShouldEqual, "6fecf53b-7553-4cb3-b97e-930f9c4e3385")
 		So(servicePlans[0].Name, ShouldEqual, "name-1575")
+		So(servicePlans[0].CreatedAt, ShouldEqual, "2016-06-08T16:41:30Z")
+		So(servicePlans[0].UpdatedAt, ShouldEqual, "2016-06-08T16:41:26Z")
 		So(servicePlans[0].Description, ShouldEqual, "desc-109")
 		So(servicePlans[0].ServiceGuid, ShouldEqual, "1ccab853-87c9-45a6-bf99-603032d17fe5")
 		So(servicePlans[0].Extra, ShouldBeNil)

--- a/services.go
+++ b/services.go
@@ -23,6 +23,8 @@ type ServicesResource struct {
 type Service struct {
 	Guid              string   `json:"guid"`
 	Label             string   `json:"label"`
+	CreatedAt         string   `json:"created_at"`
+	UpdatedAt         string   `json:"updated_at"`
 	Description       string   `json:"description"`
 	Active            bool     `json:"active"`
 	Bindable          bool     `json:"bindable"`
@@ -80,6 +82,8 @@ func (c *Client) ListServicesByQuery(query url.Values) ([]Service, error) {
 		}
 		for _, service := range serviceResp.Resources {
 			service.Entity.Guid = service.Meta.Guid
+			service.Entity.CreatedAt = service.Meta.CreatedAt
+			service.Entity.UpdatedAt = service.Meta.UpdatedAt
 			service.Entity.c = c
 			services = append(services, service.Entity)
 		}

--- a/services_test.go
+++ b/services_test.go
@@ -23,6 +23,8 @@ func TestListServices(t *testing.T) {
 		So(len(services), ShouldEqual, 2)
 		So(services[0].Guid, ShouldEqual, "a3d76c01-c08a-4505-b06d-8603265682a3")
 		So(services[0].Label, ShouldEqual, "nats")
+		So(services[0].CreatedAt, ShouldEqual, "2014-09-24T14:10:51+00:00")
+		So(services[0].UpdatedAt, ShouldEqual, "2014-10-08T00:06:30+00:00")
 		So(services[0].Description, ShouldEqual, "NATS is a lightweight cloud messaging system")
 		So(services[0].Active, ShouldEqual, true)
 		So(services[0].Bindable, ShouldEqual, true)


### PR DESCRIPTION
This PR adds both `created_at` and `updated_at` to the returned
ServicePlan when using the ListServicePlansByQuery function. These are
pulled from the Metadata for each service plan returned from the
`/v2/service_plans` endpoint.

It also adds both `created_at` and `updated_at` to the returned
Service when using the ListServiceByQuery function. These are
pulled from the Metadata for each service plan returned from the
`/v2/services` endpoint.

We require these in order to build up a versioned database of the
service plans and services we offer for the purpose of billing and reporting.

Additional fields have been added to the test cases for these functions.