### PR TITLE
Adding ability to "patch" org/space with isolation segment guid

### DIFF
--- a/cf_test.go
+++ b/cf_test.go
@@ -143,6 +143,13 @@ func setupMultipleWithRedirect(mockEndpoints []MockRouteWithRedirect, t *testing
 				testReqBody(req, postFormBody, t)
 				return status, output
 			})
+		} else if method == "PATCH" {
+			r.Patch(endpoint, func(req *http.Request) (int, string) {
+				testUserAgent(req.Header.Get("User-Agent"), userAgent, t)
+				testQueryString(req.URL.RawQuery, queryString, t)
+				testReqBody(req, postFormBody, t)
+				return status, output
+			})
 		} else if method == "PUT-FILE" {
 			r.Put(endpoint, func(req *http.Request) (int, string) {
 				testUserAgent(req.Header.Get("User-Agent"), userAgent, t)

--- a/isolationsegments.go
+++ b/isolationsegments.go
@@ -218,10 +218,7 @@ func (i *IsolationSegment) RemoveOrg(orgGuid string) error {
 	if i == nil || i.c == nil {
 		return errors.New("No communication handle.")
 	}
-	req := i.c.NewRequest("DELETE", fmt.Sprintf("/v3/isolation_segments/%s/relationships/organizations", i.GUID))
-	req.obj = map[string]interface{}{
-		"guid": orgGuid,
-	}
+	req := i.c.NewRequest("DELETE", fmt.Sprintf("/v3/isolation_segments/%s/relationships/organizations/%s", i.GUID, orgGuid))
 	resp, err := i.c.DoRequest(req)
 	if err != nil {
 		return errors.Wrapf(err, "Error during removing org %s in isolation segment %s", orgGuid, i.Name)

--- a/isolationsegments_test.go
+++ b/isolationsegments_test.go
@@ -140,7 +140,7 @@ func TestIsolationSegmentMethods(t *testing.T) {
 			{"GET", "/v3/isolation_segments", listIsolationSegmentsPayload, "", http.StatusOK, "", nil},
 			{"DELETE", "/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b", "", "", http.StatusNoContent, "", nil},
 			{"POST", "/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b/relationships/organizations", "", "", http.StatusOK, "", &postData},
-			{"DELETE", "/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b/relationships/organizations", "", "", http.StatusNoContent, "", nil},
+			{"DELETE", "/v3/isolation_segments/033b4c58-12bb-499a-b05d-4b6fc9e2993b/relationships/organizations/theKittenIsTheShark", "", "", http.StatusNoContent, "", nil},
 			{"PUT", "/v2/spaces/theKittenIsTheShark", "", "", http.StatusCreated, "", nil},
 			{"DELETE", "/v2/spaces/theKittenIsTheShark/isolation_segment", "", "", http.StatusNoContent, "", nil},
 		}

--- a/orgs.go
+++ b/orgs.go
@@ -694,3 +694,29 @@ func (c *Client) mergeOrgResource(org OrgResource) Org {
 	org.Entity.c = c
 	return org.Entity
 }
+
+func (c *Client) DefaultIsolationSegmentForOrg(orgGUID, isolationSegmentGUID string) error {
+	return c.updateOrgDefaultIsolationSegment(orgGUID, map[string]interface{}{"guid": isolationSegmentGUID})
+}
+
+func (c *Client) ResetDefaultIsolationSegmentForOrg(orgGUID string) error {
+	return c.updateOrgDefaultIsolationSegment(orgGUID, nil)
+}
+
+func (c *Client) updateOrgDefaultIsolationSegment(orgGUID string, data interface{}) error {
+	requestURL := fmt.Sprintf("/v3/organizations/%s/relationships/default_isolation_segment", orgGUID)
+	buf := bytes.NewBuffer(nil)
+	err := json.NewEncoder(buf).Encode(map[string]interface{}{"data": data})
+	if err != nil {
+		return err
+	}
+	r := c.NewRequestWithBody("PATCH", requestURL, buf)
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.Wrapf(err, "Error setting default isolation segment for org %s, response code: %d", orgGUID, resp.StatusCode)
+	}
+	return nil
+}

--- a/orgs_test.go
+++ b/orgs_test.go
@@ -731,3 +731,45 @@ func TestUnshareOrgPrivateDomain(t *testing.T) {
 
 	})
 }
+
+func TestDefaultIsolationSegmentForOrg(t *testing.T) {
+	Convey("set Default IsolationSegment", t, func() {
+		defaultIsolationSegmentPayload := `{"data":{"guid":"3b6f763f-aae1-4177-9b93-f2de6f2a48f2"}}`
+		mocks := []MockRoute{
+			{"PATCH", "/v3/organizations/3b6f763f-aae1-4177-9b93-f2de6f2a48f2/relationships/default_isolation_segment", "", "", 200, "", &defaultIsolationSegmentPayload},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		err = client.DefaultIsolationSegmentForOrg("3b6f763f-aae1-4177-9b93-f2de6f2a48f2", "3b6f763f-aae1-4177-9b93-f2de6f2a48f2")
+		So(err, ShouldBeNil)
+
+	})
+}
+
+func TestResetDefaultIsolationSegmentForOrg(t *testing.T) {
+	Convey("Reset Default IsolationSegment", t, func() {
+		resetIsolationSegmentPayload := `{"data":null}`
+		mocks := []MockRoute{
+			{"PATCH", "/v3/organizations/3b6f763f-aae1-4177-9b93-f2de6f2a48f2/relationships/default_isolation_segment", "", "", 200, "", &resetIsolationSegmentPayload},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		err = client.ResetDefaultIsolationSegmentForOrg("3b6f763f-aae1-4177-9b93-f2de6f2a48f2")
+		So(err, ShouldBeNil)
+
+	})
+}

--- a/spaces.go
+++ b/spaces.go
@@ -692,3 +692,29 @@ func (resource *ServiceOfferingExtra) UnmarshalJSON(rawData []byte) error {
 
 	return nil
 }
+
+func (c *Client) IsolationSegmentForSpace(spaceGUID, isolationSegmentGUID string) error {
+	return c.updateSpaceIsolationSegment(spaceGUID, map[string]interface{}{"guid": isolationSegmentGUID})
+}
+
+func (c *Client) ResetIsolationSegmentForSpace(spaceGUID string) error {
+	return c.updateSpaceIsolationSegment(spaceGUID, nil)
+}
+
+func (c *Client) updateSpaceIsolationSegment(spaceGUID string, data interface{}) error {
+	requestURL := fmt.Sprintf("/v3/spaces/%s/relationships/isolation_segment", spaceGUID)
+	buf := bytes.NewBuffer(nil)
+	err := json.NewEncoder(buf).Encode(map[string]interface{}{"data": data})
+	if err != nil {
+		return err
+	}
+	r := c.NewRequestWithBody("PATCH", requestURL, buf)
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.Wrapf(err, "Error setting isolation segment for space %s, response code: %d", spaceGUID, resp.StatusCode)
+	}
+	return nil
+}

--- a/spaces_test.go
+++ b/spaces_test.go
@@ -542,3 +542,45 @@ func TestGetSpaceServiceOfferings(t *testing.T) {
 		So(err, ShouldBeNil)
 	})
 }
+
+func TestIsolationSegmentForSpace(t *testing.T) {
+	Convey("set Default IsolationSegment", t, func() {
+		defaultIsolationSegmentPayload := `{"data":{"guid":"3b6f763f-aae1-4177-9b93-f2de6f2a48f2"}}`
+		mocks := []MockRoute{
+			{"PATCH", "/v3/spaces/3b6f763f-aae1-4177-9b93-f2de6f2a48f2/relationships/isolation_segment", "", "", 200, "", &defaultIsolationSegmentPayload},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		err = client.IsolationSegmentForSpace("3b6f763f-aae1-4177-9b93-f2de6f2a48f2", "3b6f763f-aae1-4177-9b93-f2de6f2a48f2")
+		So(err, ShouldBeNil)
+
+	})
+}
+
+func TestResetIsolationSegmentForSpace(t *testing.T) {
+	Convey("Reset IsolationSegment", t, func() {
+		resetIsolationSegmentPayload := `{"data":null}`
+		mocks := []MockRoute{
+			{"PATCH", "/v3/spaces/3b6f763f-aae1-4177-9b93-f2de6f2a48f2/relationships/isolation_segment", "", "", 200, "", &resetIsolationSegmentPayload},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		err = client.ResetIsolationSegmentForSpace("3b6f763f-aae1-4177-9b93-f2de6f2a48f2")
+		So(err, ShouldBeNil)
+
+	})
+}


### PR DESCRIPTION
Per v3 docs

http://v3-apidocs.cloudfoundry.org/version/3.50.0/#assign-default-isolation-segment
http://v3-apidocs.cloudfoundry.org/version/3.50.0/#manage-isolation-segment