### PR TITLE
Added GetSharedDomainByGuid

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -133,6 +133,17 @@ func (c *Client) ListSharedDomains() ([]SharedDomain, error) {
 	return c.ListSharedDomainsByQuery(nil)
 }
 
+func (c *Client) GetSharedDomainByGuid(guid string) (SharedDomain, error) {
+       r := c.NewRequest("GET", "/v2/shared_domains/"+guid)
+       resp, err := c.DoRequest(r)
+       if err != nil {
+               return SharedDomain{}, errors.Wrap(err, "Error requesting shared domain")
+       }
+       defer resp.Body.Close()
+       retval, err := c.handleSharedDomainResp(resp)
+       return *retval, err
+}
+
 func (c *Client) CreateSharedDomain(name string, internal bool, router_group_guid string) (*SharedDomain, error) {
 	req := c.NewRequest("POST", "/v2/shared_domains")
 	params := map[string]interface{}{

--- a/domains_test.go
+++ b/domains_test.go
@@ -49,6 +49,24 @@ func TestListSharedDomains(t *testing.T) {
 		So(domains[0].RouterGroupGuid, ShouldEqual, "my-random-guid")
 		So(domains[0].RouterGroupType, ShouldEqual, "tcp")
 	})
+
+	Convey("List shared domain by guid", t, func() {
+		setup(MockRoute{"GET", "/v2/shared_domains/91977695-8ad9-40db-858f-4df782603ec3", listSharedDomainByGuidPayload, "", 200, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		domain, err := client.GetSharedDomainByGuid("91977695-8ad9-40db-858f-4df782603ec3")
+		So(err, ShouldBeNil)
+
+		So(domain.Guid, ShouldEqual, "91977695-8ad9-40db-858f-4df782603ec3")
+		So(domain.Name, ShouldEqual, "apps.some.random.cf.installation.example.com")
+	})
+
 }
 
 func TestGetDomainByName(t *testing.T) {

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -2526,6 +2526,22 @@ const listSharedDomainsPayload = `{
   ]
 }`
 
+const listSharedDomainByGuidPayload = `{
+   "metadata": {
+        "guid": "91977695-8ad9-40db-858f-4df782603ec3",
+        "url": "/v2/shared_domains/91977695-8ad9-40db-858f-4df782603ec3",
+        "created_at": "2016-06-08T16:41:37Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+   },
+   "entity": {
+      "name": "apps.some.random.cf.installation.example.com",
+      "internal": false,
+      "router_group_guid": null,
+      "router_group_type": null
+   }
+}
+`
+
 const listDomainsEmptyResponse = `{
   "total_results": 0,
   "total_pages": 0,


### PR DESCRIPTION

Directly support https://apidocs.cloudfoundry.org/2.7.0/shared_domains/retrieve_a_particular_shared_domain.html 

The ```/v2/routes``` API returns a ```domain_guid```. Without this call, getting the details for that guid means getting all the shared domains and iterating over them.