### PR TITLE
Added ability to specify origin when adding/remove users from roles

### DIFF
--- a/orgs.go
+++ b/orgs.go
@@ -66,17 +66,17 @@ type OrgRequest struct {
 
 func (c *Client) ListOrgsByQuery(query url.Values) ([]Org, error) {
 	var orgs []Org
-	requestUrl := "/v2/organizations?" + query.Encode()
+	requestURL := "/v2/organizations?" + query.Encode()
 	for {
-		orgResp, err := c.getOrgResponse(requestUrl)
+		orgResp, err := c.getOrgResponse(requestURL)
 		if err != nil {
 			return []Org{}, err
 		}
 		for _, org := range orgResp.Resources {
 			orgs = append(orgs, c.mergeOrgResource(org))
 		}
-		requestUrl = orgResp.NextUrl
-		if requestUrl == "" {
+		requestURL = orgResp.NextUrl
+		if requestURL == "" {
 			break
 		}
 	}
@@ -126,8 +126,8 @@ func (c *Client) OrgSpaces(guid string) ([]Space, error) {
 
 func (o *Org) Summary() (OrgSummary, error) {
 	var orgSummary OrgSummary
-	requestUrl := fmt.Sprintf("/v2/organizations/%s/summary", o.Guid)
-	r := o.c.NewRequest("GET", requestUrl)
+	requestURL := fmt.Sprintf("/v2/organizations/%s/summary", o.Guid)
+	r := o.c.NewRequest("GET", requestURL)
 	resp, err := o.c.DoRequest(r)
 	if err != nil {
 		return OrgSummary{}, errors.Wrap(err, "Error requesting org summary")
@@ -150,8 +150,8 @@ func (o *Org) Quota() (*OrgQuota, error) {
 	if o.QuotaDefinitionGuid == "" {
 		return nil, nil
 	}
-	requestUrl := fmt.Sprintf("/v2/quota_definitions/%s", o.QuotaDefinitionGuid)
-	r := o.c.NewRequest("GET", requestUrl)
+	requestURL := fmt.Sprintf("/v2/quota_definitions/%s", o.QuotaDefinitionGuid)
+	r := o.c.NewRequest("GET", requestURL)
 	resp, err := o.c.DoRequest(r)
 	if err != nil {
 		return &OrgQuota{}, errors.Wrap(err, "Error requesting org quota")
@@ -247,6 +247,11 @@ func (c *Client) AssociateOrgManagerByUsername(orgGUID, name string) (Org, error
 	return org.AssociateManagerByUsername(name)
 }
 
+func (c *Client) AssociateOrgManagerByUsernameAndOrigin(orgGUID, name, origin string) (Org, error) {
+	org := Org{Guid: orgGUID, c: c}
+	return org.AssociateManagerByUsernameAndOrigin(name, origin)
+}
+
 func (c *Client) AssociateOrgUser(orgGUID, userGUID string) (Org, error) {
 	org := Org{Guid: orgGUID, c: c}
 	return org.AssociateUser(userGUID)
@@ -262,9 +267,19 @@ func (c *Client) AssociateOrgUserByUsername(orgGUID, name string) (Org, error) {
 	return org.AssociateUserByUsername(name)
 }
 
+func (c *Client) AssociateOrgUserByUsernameAndOrigin(orgGUID, name, origin string) (Org, error) {
+	org := Org{Guid: orgGUID, c: c}
+	return org.AssociateUserByUsernameAndOrigin(name, origin)
+}
+
 func (c *Client) AssociateOrgAuditorByUsername(orgGUID, name string) (Org, error) {
 	org := Org{Guid: orgGUID, c: c}
 	return org.AssociateAuditorByUsername(name)
+}
+
+func (c *Client) AssociateOrgAuditorByUsernameAndOrigin(orgGUID, name, origin string) (Org, error) {
+	org := Org{Guid: orgGUID, c: c}
+	return org.AssociateAuditorByUsernameAndOrigin(name, origin)
 }
 
 func (c *Client) AssociateOrgBillingManager(orgGUID, userGUID string) (Org, error) {
@@ -277,6 +292,11 @@ func (c *Client) AssociateOrgBillingManagerByUsername(orgGUID, name string) (Org
 	return org.AssociateBillingManagerByUsername(name)
 }
 
+func (c *Client) AssociateOrgBillingManagerByUsernameAndOrigin(orgGUID, name, origin string) (Org, error) {
+	org := Org{Guid: orgGUID, c: c}
+	return org.AssociateBillingManagerByUsernameAndOrigin(name, origin)
+}
+
 func (c *Client) RemoveOrgManager(orgGUID, userGUID string) error {
 	org := Org{Guid: orgGUID, c: c}
 	return org.RemoveManager(userGUID)
@@ -285,6 +305,11 @@ func (c *Client) RemoveOrgManager(orgGUID, userGUID string) error {
 func (c *Client) RemoveOrgManagerByUsername(orgGUID, name string) error {
 	org := Org{Guid: orgGUID, c: c}
 	return org.RemoveManagerByUsername(name)
+}
+
+func (c *Client) RemoveOrgManagerByUsernameAndOrigin(orgGUID, name, origin string) error {
+	org := Org{Guid: orgGUID, c: c}
+	return org.RemoveManagerByUsernameAndOrigin(name, origin)
 }
 
 func (c *Client) RemoveOrgUser(orgGUID, userGUID string) error {
@@ -302,9 +327,19 @@ func (c *Client) RemoveOrgUserByUsername(orgGUID, name string) error {
 	return org.RemoveUserByUsername(name)
 }
 
+func (c *Client) RemoveOrgUserByUsernameAndOrigin(orgGUID, name, origin string) error {
+	org := Org{Guid: orgGUID, c: c}
+	return org.RemoveUserByUsernameAndOrigin(name, origin)
+}
+
 func (c *Client) RemoveOrgAuditorByUsername(orgGUID, name string) error {
 	org := Org{Guid: orgGUID, c: c}
 	return org.RemoveAuditorByUsername(name)
+}
+
+func (c *Client) RemoveOrgAuditorByUsernameAndOrigin(orgGUID, name, origin string) error {
+	org := Org{Guid: orgGUID, c: c}
+	return org.RemoveAuditorByUsernameAndOrigin(name, origin)
 }
 
 func (c *Client) RemoveOrgBillingManager(orgGUID, userGUID string) error {
@@ -315,6 +350,11 @@ func (c *Client) RemoveOrgBillingManager(orgGUID, userGUID string) error {
 func (c *Client) RemoveOrgBillingManagerByUsername(orgGUID, name string) error {
 	org := Org{Guid: orgGUID, c: c}
 	return org.RemoveBillingManagerByUsername(name)
+}
+
+func (c *Client) RemoveOrgBillingManagerByUsernameAndOrigin(orgGUID, name, origin string) error {
+	org := Org{Guid: orgGUID, c: c}
+	return org.RemoveBillingManagerByUsernameAndOrigin(name, origin)
 }
 
 func (c *Client) ListOrgSpaceQuotas(orgGUID string) ([]SpaceQuota, error) {
@@ -402,8 +442,8 @@ func (o *Org) UnsharePrivateDomain(privateDomainGUID string) error {
 }
 
 func (o *Org) associateRole(userGUID, role string) (Org, error) {
-	requestUrl := fmt.Sprintf("/v2/organizations/%s/%s/%s", o.Guid, role, userGUID)
-	r := o.c.NewRequest("PUT", requestUrl)
+	requestURL := fmt.Sprintf("/v2/organizations/%s/%s/%s", o.Guid, role, userGUID)
+	r := o.c.NewRequest("PUT", requestURL)
 	resp, err := o.c.DoRequest(r)
 	if err != nil {
 		return Org{}, err
@@ -414,14 +454,19 @@ func (o *Org) associateRole(userGUID, role string) (Org, error) {
 	return o.c.handleOrgResp(resp)
 }
 
-func (o *Org) associateRoleByUsername(name, role string) (Org, error) {
-	requestUrl := fmt.Sprintf("/v2/organizations/%s/%s", o.Guid, role)
+func (o *Org) associateRoleByUsernameAndOrigin(name, role, origin string) (Org, error) {
+	requestURL := fmt.Sprintf("/v2/organizations/%s/%s", o.Guid, role)
 	buf := bytes.NewBuffer(nil)
-	err := json.NewEncoder(buf).Encode(map[string]string{"username": name})
+	payload := make(map[string]string)
+	payload["username"] = name
+	if origin != "" {
+		payload["origin"] = origin
+	}
+	err := json.NewEncoder(buf).Encode(payload)
 	if err != nil {
 		return Org{}, err
 	}
-	r := o.c.NewRequestWithBody("PUT", requestUrl, buf)
+	r := o.c.NewRequestWithBody("PUT", requestURL, buf)
 	resp, err := o.c.DoRequest(r)
 	if err != nil {
 		return Org{}, err
@@ -437,12 +482,16 @@ func (o *Org) AssociateManager(userGUID string) (Org, error) {
 }
 
 func (o *Org) AssociateManagerByUsername(name string) (Org, error) {
-	return o.associateRoleByUsername(name, "managers")
+	return o.associateRoleByUsernameAndOrigin(name, "managers", "")
+}
+
+func (o *Org) AssociateManagerByUsernameAndOrigin(name, origin string) (Org, error) {
+	return o.associateRoleByUsernameAndOrigin(name, "managers", origin)
 }
 
 func (o *Org) AssociateUser(userGUID string) (Org, error) {
-	requestUrl := fmt.Sprintf("/v2/organizations/%s/users/%s", o.Guid, userGUID)
-	r := o.c.NewRequest("PUT", requestUrl)
+	requestURL := fmt.Sprintf("/v2/organizations/%s/users/%s", o.Guid, userGUID)
+	r := o.c.NewRequest("PUT", requestURL)
 	resp, err := o.c.DoRequest(r)
 	if err != nil {
 		return Org{}, err
@@ -458,7 +507,11 @@ func (o *Org) AssociateAuditor(userGUID string) (Org, error) {
 }
 
 func (o *Org) AssociateAuditorByUsername(name string) (Org, error) {
-	return o.associateRoleByUsername(name, "auditors")
+	return o.associateRoleByUsernameAndOrigin(name, "auditors", "")
+}
+
+func (o *Org) AssociateAuditorByUsernameAndOrigin(name, origin string) (Org, error) {
+	return o.associateRoleByUsernameAndOrigin(name, "auditors", origin)
 }
 
 func (o *Org) AssociateBillingManager(userGUID string) (Org, error) {
@@ -466,17 +519,33 @@ func (o *Org) AssociateBillingManager(userGUID string) (Org, error) {
 }
 
 func (o *Org) AssociateBillingManagerByUsername(name string) (Org, error) {
-	return o.associateRoleByUsername(name, "billing_managers")
+	return o.associateRoleByUsernameAndOrigin(name, "billing_managers", "")
+}
+func (o *Org) AssociateBillingManagerByUsernameAndOrigin(name, origin string) (Org, error) {
+	return o.associateRoleByUsernameAndOrigin(name, "billing_managers", origin)
 }
 
 func (o *Org) AssociateUserByUsername(name string) (Org, error) {
-	requestUrl := fmt.Sprintf("/v2/organizations/%s/users", o.Guid)
+	return o.associateUserByUsernameAndOrigin(name, "")
+}
+
+func (o *Org) AssociateUserByUsernameAndOrigin(name, origin string) (Org, error) {
+	return o.associateUserByUsernameAndOrigin(name, origin)
+}
+
+func (o *Org) associateUserByUsernameAndOrigin(name, origin string) (Org, error) {
+	requestURL := fmt.Sprintf("/v2/organizations/%s/users", o.Guid)
 	buf := bytes.NewBuffer(nil)
-	err := json.NewEncoder(buf).Encode(map[string]string{"username": name})
+	payload := make(map[string]string)
+	payload["username"] = name
+	if origin != "" {
+		payload["origin"] = origin
+	}
+	err := json.NewEncoder(buf).Encode(payload)
 	if err != nil {
 		return Org{}, err
 	}
-	r := o.c.NewRequestWithBody("PUT", requestUrl, buf)
+	r := o.c.NewRequestWithBody("PUT", requestURL, buf)
 	resp, err := o.c.DoRequest(r)
 	if err != nil {
 		return Org{}, err
@@ -488,8 +557,8 @@ func (o *Org) AssociateUserByUsername(name string) (Org, error) {
 }
 
 func (o *Org) removeRole(userGUID, role string) error {
-	requestUrl := fmt.Sprintf("/v2/organizations/%s/%s/%s", o.Guid, role, userGUID)
-	r := o.c.NewRequest("DELETE", requestUrl)
+	requestURL := fmt.Sprintf("/v2/organizations/%s/%s/%s", o.Guid, role, userGUID)
+	r := o.c.NewRequest("DELETE", requestURL)
 	resp, err := o.c.DoRequest(r)
 	if err != nil {
 		return err
@@ -500,14 +569,19 @@ func (o *Org) removeRole(userGUID, role string) error {
 	return nil
 }
 
-func (o *Org) removeRoleByUsername(name, role string) error {
-	requestUrl := fmt.Sprintf("/v2/organizations/%s/%s", o.Guid, role)
+func (o *Org) removeRoleByUsernameAndOrigin(name, role, origin string) error {
+	requestURL := fmt.Sprintf("/v2/organizations/%s/%s/remove", o.Guid, role)
 	buf := bytes.NewBuffer(nil)
-	err := json.NewEncoder(buf).Encode(map[string]string{"username": name})
+	payload := make(map[string]string)
+	payload["username"] = name
+	if origin != "" {
+		payload["origin"] = origin
+	}
+	err := json.NewEncoder(buf).Encode(payload)
 	if err != nil {
 		return err
 	}
-	r := o.c.NewRequestWithBody("DELETE", requestUrl, buf)
+	r := o.c.NewRequestWithBody("POST", requestURL, buf)
 	resp, err := o.c.DoRequest(r)
 	if err != nil {
 		return err
@@ -523,7 +597,10 @@ func (o *Org) RemoveManager(userGUID string) error {
 }
 
 func (o *Org) RemoveManagerByUsername(name string) error {
-	return o.removeRoleByUsername(name, "managers")
+	return o.removeRoleByUsernameAndOrigin(name, "managers", "")
+}
+func (o *Org) RemoveManagerByUsernameAndOrigin(name, origin string) error {
+	return o.removeRoleByUsernameAndOrigin(name, "managers", origin)
 }
 
 func (o *Org) RemoveAuditor(userGUID string) error {
@@ -531,7 +608,10 @@ func (o *Org) RemoveAuditor(userGUID string) error {
 }
 
 func (o *Org) RemoveAuditorByUsername(name string) error {
-	return o.removeRoleByUsername(name, "auditors")
+	return o.removeRoleByUsernameAndOrigin(name, "auditors", "")
+}
+func (o *Org) RemoveAuditorByUsernameAndOrigin(name, origin string) error {
+	return o.removeRoleByUsernameAndOrigin(name, "auditors", origin)
 }
 
 func (o *Org) RemoveBillingManager(userGUID string) error {
@@ -539,12 +619,16 @@ func (o *Org) RemoveBillingManager(userGUID string) error {
 }
 
 func (o *Org) RemoveBillingManagerByUsername(name string) error {
-	return o.removeRoleByUsername(name, "billing_managers")
+	return o.removeRoleByUsernameAndOrigin(name, "billing_managers", "")
+}
+
+func (o *Org) RemoveBillingManagerByUsernameAndOrigin(name, origin string) error {
+	return o.removeRoleByUsernameAndOrigin(name, "billing_managers", origin)
 }
 
 func (o *Org) RemoveUser(userGUID string) error {
-	requestUrl := fmt.Sprintf("/v2/organizations/%s/users/%s", o.Guid, userGUID)
-	r := o.c.NewRequest("DELETE", requestUrl)
+	requestURL := fmt.Sprintf("/v2/organizations/%s/users/%s", o.Guid, userGUID)
+	r := o.c.NewRequest("DELETE", requestURL)
 	resp, err := o.c.DoRequest(r)
 	if err != nil {
 		return err
@@ -556,13 +640,26 @@ func (o *Org) RemoveUser(userGUID string) error {
 }
 
 func (o *Org) RemoveUserByUsername(name string) error {
-	requestUrl := fmt.Sprintf("/v2/organizations/%s/users", o.Guid)
+	return o.removeUserByUsernameAndOrigin(name, "")
+}
+
+func (o *Org) RemoveUserByUsernameAndOrigin(name, origin string) error {
+	return o.removeUserByUsernameAndOrigin(name, origin)
+}
+
+func (o *Org) removeUserByUsernameAndOrigin(name, origin string) error {
+	requestURL := fmt.Sprintf("/v2/organizations/%s/users/remove", o.Guid)
 	buf := bytes.NewBuffer(nil)
-	err := json.NewEncoder(buf).Encode(map[string]string{"username": name})
+	payload := make(map[string]string)
+	payload["username"] = name
+	if origin != "" {
+		payload["origin"] = origin
+	}
+	err := json.NewEncoder(buf).Encode(payload)
 	if err != nil {
 		return err
 	}
-	r := o.c.NewRequestWithBody("DELETE", requestUrl, buf)
+	r := o.c.NewRequestWithBody("POST", requestURL, buf)
 	resp, err := o.c.DoRequest(r)
 	if err != nil {
 		return err
@@ -618,9 +715,9 @@ func (c *Client) DeleteOrg(guid string, recursive, async bool) error {
 	return nil
 }
 
-func (c *Client) getOrgResponse(requestUrl string) (OrgResponse, error) {
+func (c *Client) getOrgResponse(requestURL string) (OrgResponse, error) {
 	var orgResp OrgResponse
-	r := c.NewRequest("GET", requestUrl)
+	r := c.NewRequest("GET", requestURL)
 	resp, err := c.DoRequest(r)
 	if err != nil {
 		return OrgResponse{}, errors.Wrap(err, "Error requesting orgs")
@@ -637,18 +734,18 @@ func (c *Client) getOrgResponse(requestUrl string) (OrgResponse, error) {
 	return orgResp, nil
 }
 
-func (c *Client) fetchOrgs(requestUrl string) ([]Org, error) {
+func (c *Client) fetchOrgs(requestURL string) ([]Org, error) {
 	var orgs []Org
 	for {
-		orgResp, err := c.getOrgResponse(requestUrl)
+		orgResp, err := c.getOrgResponse(requestURL)
 		if err != nil {
 			return []Org{}, err
 		}
 		for _, org := range orgResp.Resources {
 			orgs = append(orgs, c.mergeOrgResource(org))
 		}
-		requestUrl = orgResp.NextUrl
-		if requestUrl == "" {
+		requestURL = orgResp.NextUrl
+		if requestURL == "" {
 			break
 		}
 	}

--- a/orgs_test.go
+++ b/orgs_test.go
@@ -381,7 +381,8 @@ func TestAssociateUser(t *testing.T) {
 
 func TestAssociateManagerByUsername(t *testing.T) {
 	Convey("Associate manager by username", t, func() {
-		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers", associateOrgUserPayload, "", 201, "", nil}, t)
+		expectedBody := `{"username":"user-name"}`
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers", associateOrgUserPayload, "", 201, "", &expectedBody}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -401,9 +402,33 @@ func TestAssociateManagerByUsername(t *testing.T) {
 	})
 }
 
+func TestAssociateManagerByUsernameAndOrigin(t *testing.T) {
+	Convey("Associate manager by username and origin", t, func() {
+		expectedBody := `{"origin":"ldap","username":"user-name"}`
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers", associateOrgUserPayload, "", 201, "", &expectedBody}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		org := &Org{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		newOrg, err := org.AssociateManagerByUsernameAndOrigin("user-name", "ldap")
+		So(err, ShouldBeNil)
+		So(newOrg.Guid, ShouldEqual, "bc7b4caf-f4b8-4d85-b126-0729b9351e56")
+	})
+}
+
 func TestAssociateAuditorByUsername(t *testing.T) {
 	Convey("Associate auditor by username", t, func() {
-		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", associateOrgUserPayload, "", 201, "", nil}, t)
+		expectedBody := `{"username":"user-name"}`
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", associateOrgUserPayload, "", 201, "", &expectedBody}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -423,9 +448,33 @@ func TestAssociateAuditorByUsername(t *testing.T) {
 	})
 }
 
+func TestAssociateAuditorByUsernameAndOrigin(t *testing.T) {
+	Convey("Associate auditor by username and origin", t, func() {
+		expectedBody := `{"origin":"ldap","username":"user-name"}`
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", associateOrgUserPayload, "", 201, "", &expectedBody}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		org := &Org{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		newOrg, err := org.AssociateAuditorByUsernameAndOrigin("user-name", "ldap")
+		So(err, ShouldBeNil)
+		So(newOrg.Guid, ShouldEqual, "bc7b4caf-f4b8-4d85-b126-0729b9351e56")
+	})
+}
+
 func TestAssociateBillingManagerByUsername(t *testing.T) {
 	Convey("Associate billing manager by username", t, func() {
-		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/billing_managers", associateOrgUserPayload, "", 201, "", nil}, t)
+		expectedBody := `{"username":"user-name"}`
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/billing_managers", associateOrgUserPayload, "", 201, "", &expectedBody}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -445,9 +494,33 @@ func TestAssociateBillingManagerByUsername(t *testing.T) {
 	})
 }
 
+func TestAssociateBillingManagerByUsernameAndOrigin(t *testing.T) {
+	Convey("Associate billing manager by username and origin", t, func() {
+		expectedBody := `{"origin":"ldap","username":"user-name"}`
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/billing_managers", associateOrgUserPayload, "", 201, "", &expectedBody}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		org := &Org{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		newOrg, err := org.AssociateBillingManagerByUsernameAndOrigin("user-name", "ldap")
+		So(err, ShouldBeNil)
+		So(newOrg.Guid, ShouldEqual, "bc7b4caf-f4b8-4d85-b126-0729b9351e56")
+	})
+}
+
 func TestAssociateUserByUsername(t *testing.T) {
 	Convey("Associate user by username", t, func() {
-		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users", associateOrgUserPayload, "", 201, "", nil}, t)
+		expectedBody := `{"username":"user-name"}`
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users", associateOrgUserPayload, "", 201, "", &expectedBody}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -462,6 +535,29 @@ func TestAssociateUserByUsername(t *testing.T) {
 		}
 
 		newOrg, err := org.AssociateUserByUsername("user-name")
+		So(err, ShouldBeNil)
+		So(newOrg.Guid, ShouldEqual, "bc7b4caf-f4b8-4d85-b126-0729b9351e56")
+	})
+}
+
+func TestAssociateUserByUsernameAndOrigin(t *testing.T) {
+	Convey("Associate user by username and origin", t, func() {
+		expectedBody := `{"origin":"ldap","username":"user-name"}`
+		setup(MockRoute{"PUT", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users", associateOrgUserPayload, "", 201, "", &expectedBody}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		org := &Org{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		newOrg, err := org.AssociateUserByUsernameAndOrigin("user-name", "ldap")
 		So(err, ShouldBeNil)
 		So(newOrg.Guid, ShouldEqual, "bc7b4caf-f4b8-4d85-b126-0729b9351e56")
 	})
@@ -553,7 +649,8 @@ func TestRemoveUser(t *testing.T) {
 
 func TestRemoveManagerByUsername(t *testing.T) {
 	Convey("Remove manager by username", t, func() {
-		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers", "", "", 204, "", nil}, t)
+		expectedBody := `{"username":"user-name"}`
+		setup(MockRoute{"POST", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers/remove", "", "", 204, "", &expectedBody}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -572,9 +669,32 @@ func TestRemoveManagerByUsername(t *testing.T) {
 	})
 }
 
+func TestRemoveManagerByUsernameAndOrigin(t *testing.T) {
+	Convey("Remove manager by username and origin", t, func() {
+		expectedBody := `{"origin":"ldap","username":"user-name"}`
+		setup(MockRoute{"POST", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers/remove", "", "", 204, "", &expectedBody}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		org := &Org{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		err = org.RemoveManagerByUsernameAndOrigin("user-name", "ldap")
+		So(err, ShouldBeNil)
+	})
+}
+
 func TestRemoveAuditorByUsername(t *testing.T) {
 	Convey("Remove auditor by username", t, func() {
-		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", "", "", 204, "", nil}, t)
+		expectedBody := `{"username":"user-name"}`
+		setup(MockRoute{"POST", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors/remove", "", "", 204, "", &expectedBody}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -592,10 +712,32 @@ func TestRemoveAuditorByUsername(t *testing.T) {
 		So(err, ShouldBeNil)
 	})
 }
+func TestRemoveAuditorByUsernameAndOrigin(t *testing.T) {
+	Convey("Remove auditor by username", t, func() {
+		expectedBody := `{"origin":"ldap","username":"user-name"}`
+		setup(MockRoute{"POST", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors/remove", "", "", 204, "", &expectedBody}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		org := &Org{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		err = org.RemoveAuditorByUsernameAndOrigin("user-name", "ldap")
+		So(err, ShouldBeNil)
+	})
+}
 
 func TestRemoveBillingManagerByUsername(t *testing.T) {
 	Convey("Remove billing manager by username", t, func() {
-		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/billing_managers", "", "", 204, "", nil}, t)
+		expectedBody := `{"username":"user-name"}`
+		setup(MockRoute{"POST", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/billing_managers/remove", "", "", 204, "", &expectedBody}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -614,9 +756,32 @@ func TestRemoveBillingManagerByUsername(t *testing.T) {
 	})
 }
 
+func TestRemoveBillingManagerByUsernameAndOrigin(t *testing.T) {
+	Convey("Remove billing manager by username and origin", t, func() {
+		expectedBody := `{"origin":"ldap","username":"user-name"}`
+		setup(MockRoute{"POST", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/billing_managers/remove", "", "", 204, "", &expectedBody}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		org := &Org{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		err = org.RemoveBillingManagerByUsernameAndOrigin("user-name", "ldap")
+		So(err, ShouldBeNil)
+	})
+}
+
 func TestRemoveUserByUsername(t *testing.T) {
 	Convey("Remove user by username", t, func() {
-		setup(MockRoute{"DELETE", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users", "", "", 204, "", nil}, t)
+		expectedBody := `{"username":"user-name"}`
+		setup(MockRoute{"POST", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users/remove", "", "", 204, "", &expectedBody}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -631,6 +796,28 @@ func TestRemoveUserByUsername(t *testing.T) {
 		}
 
 		err = org.RemoveUserByUsername("user-name")
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestRemoveUserByUsernameAndOrigin(t *testing.T) {
+	Convey("Remove user by username and origin", t, func() {
+		expectedBody := `{"origin":"ldap","username":"user-name"}`
+		setup(MockRoute{"POST", "/v2/organizations/bc7b4caf-f4b8-4d85-b126-0729b9351e56/users/remove", "", "", 204, "", &expectedBody}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		org := &Org{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		err = org.RemoveUserByUsernameAndOrigin("user-name", "ldap")
 		So(err, ShouldBeNil)
 	})
 }

--- a/spaces.go
+++ b/spaces.go
@@ -306,6 +306,11 @@ func (c *Client) AssociateSpaceDeveloperByUsername(spaceGUID, name string) (Spac
 	return space.AssociateDeveloperByUsername(name)
 }
 
+func (c *Client) AssociateSpaceDeveloperByUsernameAndOrigin(spaceGUID, name, origin string) (Space, error) {
+	space := Space{Guid: spaceGUID, c: c}
+	return space.AssociateDeveloperByUsernameAndOrigin(name, origin)
+}
+
 func (c *Client) RemoveSpaceDeveloper(spaceGUID, userGUID string) error {
 	space := Space{Guid: spaceGUID, c: c}
 	return space.RemoveDeveloper(userGUID)
@@ -314,6 +319,11 @@ func (c *Client) RemoveSpaceDeveloper(spaceGUID, userGUID string) error {
 func (c *Client) RemoveSpaceDeveloperByUsername(spaceGUID, name string) error {
 	space := Space{Guid: spaceGUID, c: c}
 	return space.RemoveDeveloperByUsername(name)
+}
+
+func (c *Client) RemoveSpaceDeveloperByUsernameAndOrigin(spaceGUID, name, origin string) error {
+	space := Space{Guid: spaceGUID, c: c}
+	return space.RemoveDeveloperByUsernameAndOrigin(name, origin)
 }
 
 func (c *Client) AssociateSpaceAuditor(spaceGUID, userGUID string) (Space, error) {
@@ -326,6 +336,11 @@ func (c *Client) AssociateSpaceAuditorByUsername(spaceGUID, name string) (Space,
 	return space.AssociateAuditorByUsername(name)
 }
 
+func (c *Client) AssociateSpaceAuditorByUsernameAndOrigin(spaceGUID, name, origin string) (Space, error) {
+	space := Space{Guid: spaceGUID, c: c}
+	return space.AssociateAuditorByUsernameAndOrigin(name, origin)
+}
+
 func (c *Client) RemoveSpaceAuditor(spaceGUID, userGUID string) error {
 	space := Space{Guid: spaceGUID, c: c}
 	return space.RemoveAuditor(userGUID)
@@ -334,6 +349,11 @@ func (c *Client) RemoveSpaceAuditor(spaceGUID, userGUID string) error {
 func (c *Client) RemoveSpaceAuditorByUsername(spaceGUID, name string) error {
 	space := Space{Guid: spaceGUID, c: c}
 	return space.RemoveAuditorByUsername(name)
+}
+
+func (c *Client) RemoveSpaceAuditorByUsernameAndOrigin(spaceGUID, name, origin string) error {
+	space := Space{Guid: spaceGUID, c: c}
+	return space.RemoveAuditorByUsernameAndOrigin(name, origin)
 }
 
 func (c *Client) AssociateSpaceManager(spaceGUID, userGUID string) (Space, error) {
@@ -346,6 +366,11 @@ func (c *Client) AssociateSpaceManagerByUsername(spaceGUID, name string) (Space,
 	return space.AssociateManagerByUsername(name)
 }
 
+func (c *Client) AssociateSpaceManagerByUsernameAndOrigin(spaceGUID, name, origin string) (Space, error) {
+	space := Space{Guid: spaceGUID, c: c}
+	return space.AssociateManagerByUsernameAndOrigin(name, origin)
+}
+
 func (c *Client) RemoveSpaceManager(spaceGUID, userGUID string) error {
 	space := Space{Guid: spaceGUID, c: c}
 	return space.RemoveManager(userGUID)
@@ -356,12 +381,21 @@ func (c *Client) RemoveSpaceManagerByUsername(spaceGUID, name string) error {
 	return space.RemoveManagerByUsername(name)
 }
 
+func (c *Client) RemoveSpaceManagerByUsernameAndOrigin(spaceGUID, name, origin string) error {
+	space := Space{Guid: spaceGUID, c: c}
+	return space.RemoveManagerByUsernameAndOrigin(name, origin)
+}
+
 func (s *Space) AssociateDeveloper(userGUID string) (Space, error) {
 	return s.associateRole(userGUID, "developers")
 }
 
 func (s *Space) AssociateDeveloperByUsername(name string) (Space, error) {
-	return s.associateUserByRole(name, "developers")
+	return s.associateUserByRole(name, "developers", "")
+}
+
+func (s *Space) AssociateDeveloperByUsernameAndOrigin(name, origin string) (Space, error) {
+	return s.associateUserByRole(name, "developers", origin)
 }
 
 func (s *Space) RemoveDeveloper(userGUID string) error {
@@ -369,7 +403,11 @@ func (s *Space) RemoveDeveloper(userGUID string) error {
 }
 
 func (s *Space) RemoveDeveloperByUsername(name string) error {
-	return s.removeUserByRole(name, "developers")
+	return s.removeUserByRole(name, "developers", "")
+}
+
+func (s *Space) RemoveDeveloperByUsernameAndOrigin(name, origin string) error {
+	return s.removeUserByRole(name, "developers", origin)
 }
 
 func (s *Space) AssociateAuditor(userGUID string) (Space, error) {
@@ -377,7 +415,11 @@ func (s *Space) AssociateAuditor(userGUID string) (Space, error) {
 }
 
 func (s *Space) AssociateAuditorByUsername(name string) (Space, error) {
-	return s.associateUserByRole(name, "auditors")
+	return s.associateUserByRole(name, "auditors", "")
+}
+
+func (s *Space) AssociateAuditorByUsernameAndOrigin(name, origin string) (Space, error) {
+	return s.associateUserByRole(name, "auditors", origin)
 }
 
 func (s *Space) RemoveAuditor(userGUID string) error {
@@ -385,7 +427,11 @@ func (s *Space) RemoveAuditor(userGUID string) error {
 }
 
 func (s *Space) RemoveAuditorByUsername(name string) error {
-	return s.removeUserByRole(name, "auditors")
+	return s.removeUserByRole(name, "auditors", "")
+}
+
+func (s *Space) RemoveAuditorByUsernameAndOrigin(name, origin string) error {
+	return s.removeUserByRole(name, "auditors", origin)
 }
 
 func (s *Space) AssociateManager(userGUID string) (Space, error) {
@@ -393,7 +439,11 @@ func (s *Space) AssociateManager(userGUID string) (Space, error) {
 }
 
 func (s *Space) AssociateManagerByUsername(name string) (Space, error) {
-	return s.associateUserByRole(name, "managers")
+	return s.associateUserByRole(name, "managers", "")
+}
+
+func (s *Space) AssociateManagerByUsernameAndOrigin(name, origin string) (Space, error) {
+	return s.associateUserByRole(name, "managers", origin)
 }
 
 func (s *Space) RemoveManager(userGUID string) error {
@@ -401,7 +451,10 @@ func (s *Space) RemoveManager(userGUID string) error {
 }
 
 func (s *Space) RemoveManagerByUsername(name string) error {
-	return s.removeUserByRole(name, "managers")
+	return s.removeUserByRole(name, "managers", "")
+}
+func (s *Space) RemoveManagerByUsernameAndOrigin(name, origin string) error {
+	return s.removeUserByRole(name, "managers", origin)
 }
 
 func (s *Space) associateRole(userGUID, role string) (Space, error) {
@@ -417,10 +470,15 @@ func (s *Space) associateRole(userGUID, role string) (Space, error) {
 	return s.c.handleSpaceResp(resp)
 }
 
-func (s *Space) associateUserByRole(name, role string) (Space, error) {
+func (s *Space) associateUserByRole(name, role, origin string) (Space, error) {
 	requestUrl := fmt.Sprintf("/v2/spaces/%s/%s", s.Guid, role)
 	buf := bytes.NewBuffer(nil)
-	err := json.NewEncoder(buf).Encode(map[string]string{"username": name})
+	payload := make(map[string]string)
+	payload["username"] = name
+	if origin != "" {
+		payload["origin"] = origin
+	}
+	err := json.NewEncoder(buf).Encode(payload)
 	if err != nil {
 		return Space{}, err
 	}
@@ -448,14 +506,19 @@ func (s *Space) removeRole(userGUID, role string) error {
 	return nil
 }
 
-func (s *Space) removeUserByRole(name, role string) error {
-	requestUrl := fmt.Sprintf("/v2/spaces/%s/%s", s.Guid, role)
+func (s *Space) removeUserByRole(name, role, origin string) error {
+	requestUrl := fmt.Sprintf("/v2/spaces/%s/%s/remove", s.Guid, role)
 	buf := bytes.NewBuffer(nil)
-	err := json.NewEncoder(buf).Encode(map[string]string{"username": name})
+	payload := make(map[string]string)
+	payload["username"] = name
+	if origin != "" {
+		payload["origin"] = origin
+	}
+	err := json.NewEncoder(buf).Encode(payload)
 	if err != nil {
 		return err
 	}
-	r := s.c.NewRequestWithBody("DELETE", requestUrl, buf)
+	r := s.c.NewRequestWithBody("POST", requestUrl, buf)
 	resp, err := s.c.DoRequest(r)
 	if err != nil {
 		return err

--- a/spaces_test.go
+++ b/spaces_test.go
@@ -366,7 +366,8 @@ func TestSpaceRoles(t *testing.T) {
 
 func TestAssociateSpaceAuditorByUsername(t *testing.T) {
 	Convey("Associate auditor by username", t, func() {
-		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", associateSpaceUserPayload, "", 201, "", nil}, t)
+		requestBody := `{"username":"user-name"}`
+		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", associateSpaceUserPayload, "", 201, "", &requestBody}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -386,9 +387,33 @@ func TestAssociateSpaceAuditorByUsername(t *testing.T) {
 	})
 }
 
+func TestAssociateSpaceAuditorByUsernameAndOrigin(t *testing.T) {
+	Convey("Associate auditor by username and origin", t, func() {
+		requestBody := `{"origin":"ldap","username":"user-name"}`
+		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", associateSpaceUserPayload, "", 201, "", &requestBody}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		space := &Space{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		newSpace, err := space.AssociateAuditorByUsernameAndOrigin("user-name", "ldap")
+		So(err, ShouldBeNil)
+		So(newSpace.Guid, ShouldEqual, "bc7b4caf-f4b8-4d85-b126-0729b9351e56")
+	})
+}
+
 func TestAssociateSpaceDeveloperByUsername(t *testing.T) {
 	Convey("Associate developer by username", t, func() {
-		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/developers", associateSpaceUserPayload, "", 201, "", nil}, t)
+		requestBody := `{"username":"user-name"}`
+		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/developers", associateSpaceUserPayload, "", 201, "", &requestBody}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -408,9 +433,33 @@ func TestAssociateSpaceDeveloperByUsername(t *testing.T) {
 	})
 }
 
+func TestAssociateSpaceDeveloperByUsernameAndOrigin(t *testing.T) {
+	Convey("Associate developer by username and origin", t, func() {
+		requestBody := `{"origin":"ldap","username":"user-name"}`
+		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/developers", associateSpaceUserPayload, "", 201, "", &requestBody}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		space := &Space{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		newSpace, err := space.AssociateDeveloperByUsernameAndOrigin("user-name", "ldap")
+		So(err, ShouldBeNil)
+		So(newSpace.Guid, ShouldEqual, "bc7b4caf-f4b8-4d85-b126-0729b9351e56")
+	})
+}
+
 func TestAssociateSpaceManagerByUsername(t *testing.T) {
 	Convey("Associate manager by username", t, func() {
-		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers", associateSpaceUserPayload, "", 201, "", nil}, t)
+		requestBody := `{"username":"user-name"}`
+		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers", associateSpaceUserPayload, "", 201, "", &requestBody}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -430,9 +479,33 @@ func TestAssociateSpaceManagerByUsername(t *testing.T) {
 	})
 }
 
+func TestAssociateSpaceManagerByUsernameAndOrigin(t *testing.T) {
+	Convey("Associate manager by username and origin", t, func() {
+		requestBody := `{"origin":"ldap","username":"user-name"}`
+		setup(MockRoute{"PUT", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers", associateSpaceUserPayload, "", 201, "", &requestBody}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		space := &Space{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		newSpace, err := space.AssociateManagerByUsernameAndOrigin("user-name", "ldap")
+		So(err, ShouldBeNil)
+		So(newSpace.Guid, ShouldEqual, "bc7b4caf-f4b8-4d85-b126-0729b9351e56")
+	})
+}
+
 func TestRemoveSpaceDeveloperByUsername(t *testing.T) {
 	Convey("Remove developer by username", t, func() {
-		setup(MockRoute{"DELETE", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/developers", "", "", 200, "", nil}, t)
+		requestBody := `{"username":"user-name"}`
+		setup(MockRoute{"POST", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/developers/remove", "", "", 200, "", &requestBody}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -450,9 +523,31 @@ func TestRemoveSpaceDeveloperByUsername(t *testing.T) {
 		So(err, ShouldBeNil)
 	})
 }
+func TestRemoveSpaceDeveloperByUsernameAndOrigin(t *testing.T) {
+	Convey("Remove developer by username and origin", t, func() {
+		requestBody := `{"origin":"ldap","username":"user-name"}`
+		setup(MockRoute{"POST", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/developers/remove", "", "", 200, "", &requestBody}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		space := &Space{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		err = space.RemoveDeveloperByUsernameAndOrigin("user-name", "ldap")
+		So(err, ShouldBeNil)
+	})
+}
 func TestRemoveSpaceAuditorByUsername(t *testing.T) {
 	Convey("Remove auditor by username", t, func() {
-		setup(MockRoute{"DELETE", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors", "", "", 200, "", nil}, t)
+		requestBody := `{"username":"user-name"}`
+		setup(MockRoute{"POST", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors/remove", "", "", 200, "", &requestBody}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -471,9 +566,32 @@ func TestRemoveSpaceAuditorByUsername(t *testing.T) {
 	})
 }
 
+func TestRemoveSpaceAuditorByUsernameAndOrigin(t *testing.T) {
+	Convey("Remove auditor by username and origin", t, func() {
+		requestBody := `{"origin":"ldap","username":"user-name"}`
+		setup(MockRoute{"POST", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/auditors/remove", "", "", 200, "", &requestBody}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		space := &Space{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		err = space.RemoveAuditorByUsernameAndOrigin("user-name", "ldap")
+		So(err, ShouldBeNil)
+	})
+}
+
 func TestRemoveSpaceManagerByUsername(t *testing.T) {
 	Convey("Remove manager by username", t, func() {
-		setup(MockRoute{"DELETE", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers", "", "", 200, "", nil}, t)
+		requestBody := `{"username":"user-name"}`
+		setup(MockRoute{"POST", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers/remove", "", "", 200, "", &requestBody}, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -488,6 +606,28 @@ func TestRemoveSpaceManagerByUsername(t *testing.T) {
 		}
 
 		err = space.RemoveManagerByUsername("user-name")
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestRemoveSpaceManagerByUsernameAndOrigin(t *testing.T) {
+	Convey("Remove manager by username and origin", t, func() {
+		requestBody := `{"origin":"ldap","username":"user-name"}`
+		setup(MockRoute{"POST", "/v2/spaces/bc7b4caf-f4b8-4d85-b126-0729b9351e56/managers/remove", "", "", 200, "", &requestBody}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		space := &Space{
+			Guid: "bc7b4caf-f4b8-4d85-b126-0729b9351e56",
+			c:    client,
+		}
+
+		err = space.RemoveManagerByUsernameAndOrigin("user-name", "ldap")
 		So(err, ShouldBeNil)
 	})
 }


### PR DESCRIPTION
If you have users with the same username but different origin (uaa,ldap,saml) then you need to specify the origin when adding/removing from org/space roles otherwise will get the following error if 2 users exist with same user name but different origin `cfclient: error (20006): CF-UserIsInMultipleOrigins`