### PR TITLE
Support searching multiple pages when listing service keys, bindings

### DIFF
--- a/payloads_test.go
+++ b/payloads_test.go
@@ -1575,11 +1575,11 @@ const orgPayload = `{
    }
 }`
 
-const listServiceBindingsPayload = `{
-  "total_results": 1,
-  "total_pages": 1,
+const listServiceBindingsPayloadPage1 = `{
+  "total_results": 2,
+  "total_pages": 2,
   "prev_url": null,
-  "next_url": null,
+  "next_url": "/v2/service_bindings2",
   "resources": [
     {
       "metadata": {
@@ -1605,6 +1605,41 @@ const listServiceBindingsPayload = `{
         ],
         "app_url": "/v2/apps/b26e7e98-f002-41a8-a663-1b60f808a92a",
         "service_instance_url": "/v2/service_instances/bde206e0-1ee8-48ad-b794-44c857633d50"
+      }
+    }
+  ]
+}`
+
+const listServiceBindingsPayloadPage2 = `{
+  "total_results": 2,
+  "total_pages": 2,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "8201b87d-b273-4fdf-8dd4-4b42ce970cc7",
+        "url": "/v2/service_bindings/aa599bb3-4811-405a-bbe3-a68c7c55afc8",
+        "created_at": "2016-06-08T16:41:43Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "app_guid": "636bbf83-5b54-488d-9528-066f680a99dc",
+        "service_instance_guid": "c3023201-44f5-4dc8-a903-c69c9eba9809",
+        "credentials": {
+          "creds-key-66": "creds-val-66"
+        },
+        "binding_options": {
+
+        },
+        "gateway_data": null,
+        "gateway_name": "",
+        "syslog_drain_url": null,
+        "volume_mounts": [
+
+        ],
+        "app_url": "/v2/apps/636bbf83-5b54-488d-9528-066f680a99dc",
+        "service_instance_url": "/v2/service_instances/c3023201-44f5-4dc8-a903-c69c9eba9809"
       }
     }
   ]
@@ -3001,9 +3036,66 @@ const listIsolationSegmentsPayload = `{
    ]
 }`
 
-const listServiceKeysPayload = `{
-   "total_results": 2,
-   "total_pages": 1,
+const listServiceKeysPayloadPage1 = `{
+   "total_results": 4,
+   "total_pages": 2,
+   "prev_url": null,
+   "next_url": "/v2/service_keys2",
+   "resources": [
+      {
+         "metadata": {
+            "guid": "3b933598-64ed-4613-a0f5-b7e8c0379368",
+            "url": "/v2/service_keys/3b933598-64ed-4613-a0f5-b7e8c0379368",
+            "created_at": "2016-08-01T15:17:35Z",
+            "updated_at": "2016-08-01T15:17:35Z"
+         },
+         "entity": {
+            "name": "RedisMonitoringKey",
+            "service_instance_guid": "ad98f310-a3a0-47aa-9116-f8295d41a9b2",
+            "credentials": {
+               "host": "10.10.10.10",
+               "password": "some-password",
+               "port": 12345
+            },
+            "service_instance_url": "/v2/service_instances/ad98f310-a3a0-47aa-9116-f8295d41a9b2"
+         }
+      },
+      {
+         "metadata": {
+            "guid": "8be3911b-c621-4467-8866-f8b924aaee57",
+            "url": "/v2/service_keys/8be3911b-c621-4467-8866-f8b924aaee57",
+            "created_at": "2017-05-16T12:14:46Z",
+            "updated_at": "2017-05-16T12:14:46Z"
+         },
+         "entity": {
+            "name": "test01_key",
+            "service_instance_guid": "ecf26687-e176-4784-b181-b3c942fecb62",
+            "credentials": {
+               "jms": "nhp://100.100.100.100:9008",
+               "js_uri": "http://100.100.100.100:9008",
+               "amqp": "amqp://100.100.100.100:9008",
+               "nhp": "nhp://100.100.100.100:9009",
+               "mqtt": "tcp://100.100.100.100:9008",
+               "name": "fcf26687-e176-4784-b181-b3c942fecb62",
+               "nsp": "nsp://100.100.100.100:9008",
+               "userid": "cfu-9be3911b-c621-4467-8866-f8b924aaee57",
+               "uri": "nhp://100.100.100.100:9008",
+               "uriInfos": [
+                  {
+                     "host": "100.100.100.100",
+                     "port": 9008
+                  }
+               ]
+            },
+            "service_instance_url": "/v2/service_instances/fcf26687-e176-4784-b181-b3c942fecb62"
+        }
+    }
+  ]
+}`
+
+const listServiceKeysPayloadPage2 = `{
+   "total_results": 4,
+   "total_pages": 2,
    "prev_url": null,
    "next_url": null,
    "resources": [

--- a/service_bindings.go
+++ b/service_bindings.go
@@ -42,11 +42,11 @@ type ServiceBinding struct {
 
 func (c *Client) ListServiceBindingsByQuery(query url.Values) ([]ServiceBinding, error) {
 	var serviceBindings []ServiceBinding
-	var serviceBindingsResp ServiceBindingsResponse
-	pages := 0
-
 	requestUrl := "/v2/service_bindings?" + query.Encode()
+
 	for {
+		var serviceBindingsResp ServiceBindingsResponse
+
 		r := c.NewRequest("GET", requestUrl)
 		resp, err := c.DoRequest(r)
 		if err != nil {
@@ -72,12 +72,8 @@ func (c *Client) ListServiceBindingsByQuery(query url.Values) ([]ServiceBinding,
 		if requestUrl == "" {
 			break
 		}
-		pages += 1
-		totalPages := serviceBindingsResp.Pages
-		if totalPages > 0 && pages >= totalPages {
-			break
-		}
 	}
+
 	return serviceBindings, nil
 }
 

--- a/service_bindings_test.go
+++ b/service_bindings_test.go
@@ -10,7 +10,21 @@ import (
 
 func TestListServiceBindings(t *testing.T) {
 	Convey("List Service Bindings", t, func() {
-		setup(MockRoute{"GET", "/v2/service_bindings", listServiceBindingsPayload, "", 200, "", nil}, t)
+		mocks := []MockRoute{
+			{
+				Method:   "GET",
+				Endpoint: "/v2/service_bindings",
+				Output:   listServiceBindingsPayloadPage1,
+				Status:   200,
+			},
+			{
+				Method:   "GET",
+				Endpoint: "/v2/service_bindings2",
+				Output:   listServiceBindingsPayloadPage2,
+				Status:   200,
+			},
+		}
+		setupMultiple(mocks, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -22,7 +36,7 @@ func TestListServiceBindings(t *testing.T) {
 		serviceBindings, err := client.ListServiceBindings()
 		So(err, ShouldBeNil)
 
-		So(len(serviceBindings), ShouldEqual, 1)
+		So(len(serviceBindings), ShouldEqual, 2)
 		So(serviceBindings[0].Guid, ShouldEqual, "aa599bb3-4811-405a-bbe3-a68c7c55afc8")
 		So(serviceBindings[0].AppGuid, ShouldEqual, "b26e7e98-f002-41a8-a663-1b60f808a92a")
 		So(serviceBindings[0].ServiceInstanceGuid, ShouldEqual, "bde206e0-1ee8-48ad-b794-44c857633d50")
@@ -36,6 +50,20 @@ func TestListServiceBindings(t *testing.T) {
 		So(serviceBindings[0].VolumeMounts, ShouldBeEmpty)
 		So(serviceBindings[0].AppUrl, ShouldEqual, "/v2/apps/b26e7e98-f002-41a8-a663-1b60f808a92a")
 		So(serviceBindings[0].ServiceInstanceUrl, ShouldEqual, "/v2/service_instances/bde206e0-1ee8-48ad-b794-44c857633d50")
+		So(serviceBindings[1].Guid, ShouldEqual, "8201b87d-b273-4fdf-8dd4-4b42ce970cc7")
+		So(serviceBindings[1].AppGuid, ShouldEqual, "636bbf83-5b54-488d-9528-066f680a99dc")
+		So(serviceBindings[1].ServiceInstanceGuid, ShouldEqual, "c3023201-44f5-4dc8-a903-c69c9eba9809")
+		So(reflect.DeepEqual(
+			serviceBindings[1].Credentials,
+			map[string]interface{}{"creds-key-66": "creds-val-66"}), ShouldBeTrue)
+		So(serviceBindings[1].BindingOptions, ShouldBeEmpty)
+		So(serviceBindings[1].GatewayData, ShouldBeNil)
+		So(serviceBindings[1].GatewayName, ShouldEqual, "")
+		So(serviceBindings[1].SyslogDrainUrl, ShouldEqual, "")
+		So(serviceBindings[1].VolumeMounts, ShouldBeEmpty)
+		So(serviceBindings[1].AppUrl, ShouldEqual, "/v2/apps/636bbf83-5b54-488d-9528-066f680a99dc")
+		So(serviceBindings[1].ServiceInstanceUrl, ShouldEqual, "/v2/service_instances/c3023201-44f5-4dc8-a903-c69c9eba9809")
+
 	})
 }
 func TestServiceBindingByGuid(t *testing.T) {

--- a/service_keys_test.go
+++ b/service_keys_test.go
@@ -8,7 +8,21 @@ import (
 
 func TestListServiceKeys(t *testing.T) {
 	Convey("List Service Keys", t, func() {
-		setup(MockRoute{"GET", "/v2/service_keys", listServiceKeysPayload, "", 200, "", nil}, t)
+		mocks := []MockRoute{
+			{
+				Method:   "GET",
+				Endpoint: "/v2/service_keys",
+				Output:   listServiceKeysPayloadPage1,
+				Status:   200,
+			},
+			{
+				Method:   "GET",
+				Endpoint: "/v2/service_keys2",
+				Output:   listServiceKeysPayloadPage2,
+				Status:   200,
+			},
+		}
+		setupMultiple(mocks, t)
 		defer teardown()
 		c := &Config{
 			ApiAddress: server.URL,
@@ -20,7 +34,7 @@ func TestListServiceKeys(t *testing.T) {
 		serviceKeys, err := client.ListServiceKeys()
 		So(err, ShouldBeNil)
 
-		So(len(serviceKeys), ShouldEqual, 2)
+		So(len(serviceKeys), ShouldEqual, 4)
 		So(serviceKeys[0].Guid, ShouldEqual, "3b933598-64ed-4613-a0f5-b7e8c0379368")
 		So(serviceKeys[0].Name, ShouldEqual, "RedisMonitoringKey")
 		So(serviceKeys[0].ServiceInstanceGuid, ShouldEqual, "ad98f310-a3a0-47aa-9116-f8295d41a9b2")
@@ -33,6 +47,18 @@ func TestListServiceKeys(t *testing.T) {
 		m := serviceKeys[1].Credentials.(map[string]interface{})
 		So(m["uri"], ShouldEqual, "nhp://100.100.100.100:9008")
 		So(serviceKeys[1].ServiceInstanceUrl, ShouldEqual, "/v2/service_instances/fcf26687-e176-4784-b181-b3c942fecb62")
+		So(serviceKeys[2].Guid, ShouldEqual, "3b933598-64ed-4613-a0f5-b7e8c0379368")
+		So(serviceKeys[2].Name, ShouldEqual, "RedisMonitoringKey")
+		So(serviceKeys[2].ServiceInstanceGuid, ShouldEqual, "ad98f310-a3a0-47aa-9116-f8295d41a9b2")
+		So(serviceKeys[2].Credentials, ShouldNotEqual, nil)
+		So(serviceKeys[2].ServiceInstanceUrl, ShouldEqual, "/v2/service_instances/ad98f310-a3a0-47aa-9116-f8295d41a9b2")
+		So(serviceKeys[3].Guid, ShouldEqual, "8be3911b-c621-4467-8866-f8b924aaee57")
+		So(serviceKeys[3].Name, ShouldEqual, "test01_key")
+		So(serviceKeys[3].ServiceInstanceGuid, ShouldEqual, "ecf26687-e176-4784-b181-b3c942fecb62")
+		So(serviceKeys[3].Credentials, ShouldNotEqual, nil)
+		m = serviceKeys[3].Credentials.(map[string]interface{})
+		So(m["uri"], ShouldEqual, "nhp://100.100.100.100:9008")
+		So(serviceKeys[3].ServiceInstanceUrl, ShouldEqual, "/v2/service_instances/fcf26687-e176-4784-b181-b3c942fecb62")
 	})
 }
 


### PR DESCRIPTION
Hello!

@abg and I are working on a utility that uses this package, and noticed that the ListServiceKeysByQuery function didn't have page support, so we added that in in this PR. We also cleaned up the implementation of ListServiceBindingsByQuery to remove the unnecessary `page` counting, and added test coverage for these two functions' paging feature.

Let us know if there's anything else we can do to help make this shippable!