### PR TITLE
Handle and convert errors from APIs V3 into V2 model

### DIFF
--- a/error.go
+++ b/error.go
@@ -6,24 +6,37 @@ import (
 	"fmt"
 )
 
-type CloudFoundryErrors struct {
-	Errors []CloudFoundryError `json:"errors"`
-}
-
-func (cfErrs CloudFoundryErrors) Error() string {
-	err := ""
-
-	for _, cfErr := range cfErrs.Errors {
-		err += fmt.Sprintf("%s\n", cfErr)
-	}
-
-	return err
-}
-
 type CloudFoundryError struct {
 	Code        int    `json:"code"`
 	ErrorCode   string `json:"error_code"`
 	Description string `json:"description"`
+}
+
+type CloudFoundryErrorsV3 struct {
+	Errors []CloudFoundryErrorV3 `json:"errors"`
+}
+
+type CloudFoundryErrorV3 struct {
+	Code   int    `json:"code"`
+	Title  string `json:"title"`
+	Detail string `json:"detail"`
+}
+
+// CF APIs v3 can return multiple errors, we take the first one and convert it into a V2 model
+func NewCloudFoundryErrorFromV3Errors(cfErrorsV3 CloudFoundryErrorsV3) CloudFoundryError {
+	if len(cfErrorsV3.Errors) == 0 {
+		return CloudFoundryError{
+			0,
+			"GO-Client-No-Errors",
+			"No Errors in response from V3",
+		}
+	}
+
+	return CloudFoundryError{
+		cfErrorsV3.Errors[0].Code,
+		cfErrorsV3.Errors[0].Title,
+		cfErrorsV3.Errors[0].Detail,
+	}
 }
 
 func (cfErr CloudFoundryError) Error() string {

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -2474,6 +2474,18 @@ const createTaskPayload = `
   }
 }
 `
+
+const errorV3Payload = `{
+  "errors": [
+    {
+      "code": 10008,
+      "title": "CF-UnprocessableEntity",
+      "detail": "something went wrong"
+    }
+  ]
+}
+`
+
 const listDomainsPayload = `{
   "total_results": 4,
   "total_pages": 1,

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -112,6 +112,34 @@ func TestCreateTask(t *testing.T) {
 	})
 }
 
+func TestCreateTaskFails(t *testing.T) {
+	Convey("Create Task fails", t, func() {
+		mocks := []MockRoute{
+			{"POST", "/v3/apps/740ebd2b-162b-469a-bd72-3edb96fabd9a/tasks", errorV3Payload, "", 400, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		tr := TaskRequest{
+			Command:          "rake db:migrate",
+			Name:             "migrate",
+			MemoryInMegabyte: 512,
+			DiskInMegabyte:   1024,
+			DropletGUID:      "740ebd2b-162b-469a-bd72-3edb96fabd9a",
+		}
+
+		task, err := client.CreateTask(tr)
+		So(err.Error(), ShouldEqual, "Error creating task: cfclient error (CF-UnprocessableEntity|10008): something went wrong")
+		So(task.Name, ShouldBeEmpty)
+	})
+}
+
 func TestTerminateTask(t *testing.T) {
 	Convey("Terminate Task", t, func() {
 		mocks := []MockRoute{


### PR DESCRIPTION
CloudFoundry APIs in V3 returns a different model than V2.
Currently this library only handle the V2 model (see #108) and fails if the V3 model is returned from the API.

This PR is related to https://github.com/cloudfoundry-community/go-cfclient/issues/203

- [x] Handle errors from APIx in V3 and convert them into a CloudFoundryError model
- [x] Add test for task-create failure (API v3 error)


\cc @dbu 