### PR TITLE
remove username/password when cf app is not a docker image

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -45,8 +45,8 @@ const (
 )
 
 type DockerCredentials struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
 }
 
 type AppCreateRequest struct {


### PR DESCRIPTION
When creating a **Non-Docker** app with this library a `docker_credentials` block is added to the JSON request. This is due to the actual `username` and `password` not containing the `omitempty` flag. 

This PR fixes the issue allowing users to use AppCreateRequests for non-docker use cases.