### PR TITLE
Add App.Summary() func

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -244,6 +244,26 @@ func (a *App) Space() (Space, error) {
 	return a.c.mergeSpaceResource(spaceResource), nil
 }
 
+func (a *App) Summary() (AppSummary, error) {
+	var appSummary AppSummary
+	requestUrl := fmt.Sprintf("/v2/apps/%s/summary", a.Guid)
+	r := a.c.NewRequest("GET", requestUrl)
+	resp, err := a.c.DoRequest(r)
+	if err != nil {
+		return AppSummary{}, errors.Wrap(err, "Error requesting app summary")
+	}
+	resBody, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return AppSummary{}, errors.Wrap(err, "Error reading app summary body")
+	}
+	err = json.Unmarshal(resBody, &appSummary)
+	if err != nil {
+		return AppSummary{}, errors.Wrap(err, "Error unmarshalling app summary")
+	}
+	return appSummary, nil
+}
+
 // ListAppsByQueryWithLimits queries totalPages app info. When totalPages is
 // less and equal than 0, it queries all app info
 // When there are no more than totalPages apps on server side, all apps info will be returned

--- a/apps_test.go
+++ b/apps_test.go
@@ -406,6 +406,51 @@ func TestAppEnv(t *testing.T) {
 	})
 }
 
+func TestAppSummary(t *testing.T) {
+	Convey("Get app summary", t, func() {
+		setup(MockRoute{"GET", "/v2/apps/b5f0d1bd-a3a9-40a4-af1a-312ad26e5379/summary", appSummaryPayload, "", 200, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		app := &App{
+			Guid: "b5f0d1bd-a3a9-40a4-af1a-312ad26e5379",
+			c:    client,
+		}
+
+		summary, err := app.Summary()
+		So(err, ShouldBeNil)
+
+		So(summary.Guid, ShouldEqual, "b5f0d1bd-a3a9-40a4-af1a-312ad26e5379")
+		So(summary.Name, ShouldEqual, "test-app")
+		So(summary.ServiceCount, ShouldEqual, 1)
+		So(summary.RunningInstances, ShouldEqual, 1)
+		So(summary.SpaceGuid, ShouldEqual, "494d8b64-8181-4183-a6d3-6279db8fec6e")
+		So(summary.StackGuid, ShouldEqual, "67e019a3-322a-407a-96e0-178e95bd0e55")
+		So(summary.Buildpack, ShouldEqual, "ruby_buildpack")
+		So(summary.DetectedBuildpack, ShouldEqual, "")
+		So(summary.Memory, ShouldEqual, 256)
+		So(summary.Instances, ShouldEqual, 1)
+		So(summary.DiskQuota, ShouldEqual, 512)
+		So(summary.State, ShouldEqual, "STARTED")
+		So(summary.Command, ShouldEqual, "")
+		So(summary.PackageState, ShouldEqual, "STAGED")
+		So(summary.HealthCheckType, ShouldEqual, "port")
+		So(summary.HealthCheckTimeout, ShouldEqual, 0)
+		So(summary.StagingFailedReason, ShouldEqual, "")
+		So(summary.StagingFailedDescription, ShouldEqual, "")
+		So(summary.Diego, ShouldEqual, true)
+		So(summary.DockerImage, ShouldEqual, "")
+		So(summary.DetectedStartCommand, ShouldEqual, "rackup -p $PORT")
+		So(summary.EnableSSH, ShouldEqual, true)
+		So(summary.DockerCredentials["redacted_message"], ShouldEqual, "[PRIVATE DATA HIDDEN]")
+	})
+}
+
 func TestAppSpace(t *testing.T) {
 	Convey("Find app space", t, func() {
 		setup(MockRoute{"GET", "/v2/spaces/foobar", spacePayload, "", 200, "", nil}, t)

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -718,6 +718,61 @@ const associateSpaceUserPayload = `{
    }
 }`
 
+const appSummaryPayload = `{
+   "guid": "b5f0d1bd-a3a9-40a4-af1a-312ad26e5379",
+   "urls": [
+      "test-app.local.pcfdev.io"
+   ],
+   "routes": [
+      {
+         "guid": "0b44af3e-77e0-4821-abd6-18d8c79309e6",
+         "host": "test-app",
+         "port": null,
+         "path": "",
+         "domain": {
+            "guid": "0b183484-45cc-4855-94d4-892f80f20c13",
+            "name": "local.pcfdev.io"
+         }
+      }
+   ],
+   "service_count": 1,
+   "service_names": [
+      "test-service"
+   ],
+   "running_instances": 1,
+   "name": "test-app",
+   "production": false,
+   "space_guid": "494d8b64-8181-4183-a6d3-6279db8fec6e",
+   "stack_guid": "67e019a3-322a-407a-96e0-178e95bd0e55",
+   "buildpack": "ruby_buildpack",
+   "detected_buildpack": "",
+   "detected_buildpack_guid": "d5860c89-fb0a-49f4-a8b7-3220ff91c91d",
+   "environment_json": {},
+   "memory": 256,
+   "instances": 1,
+   "disk_quota": 512,
+   "state": "STARTED",
+   "version": "fa47ec0a-adba-4cc5-b0ee-a8570dc49b3d",
+   "command": null,
+   "console": false,
+   "debug": null,
+   "staging_task_id": "a21d69a7-0878-4841-ab53-4b515397dc27",
+   "package_state": "STAGED",
+   "health_check_type": "port",
+   "health_check_timeout": null,
+   "staging_failed_reason": null,
+   "staging_failed_description": null,
+   "diego": true,
+   "docker_image": null,
+   "package_updated_at": "2017-02-05T12:18:04Z",
+   "detected_start_command": "rackup -p $PORT",
+   "enable_ssh": true,
+   "docker_credentials_json": {
+      "redacted_message": "[PRIVATE DATA HIDDEN]"
+   },
+   "ports": null
+}`
+
 const spaceSummaryPayload = `{
    "guid": "494d8b64-8181-4183-a6d3-6279db8fec6e",
    "name": "test",


### PR DESCRIPTION
* currently the only way to get an AppSummary struct is via space.Summary()
  which isn't always the nicest
* AppSummary has occaisionally useful information, such as RunningInstances
  which is unique to AppSummary
* I'd like to use this to find apps where RunningInstances < Instances
  (eg, apps having "issues")