### PR TITLE
Add missing functions for Iso Segments

### DIFF
--- a/client_interface.go
+++ b/client_interface.go
@@ -45,6 +45,7 @@ type CloudFoundryClient interface {
 	ListIsolationSegmentsByQuery(query url.Values) ([]IsolationSegment, error)
 	ListIsolationSegments() ([]IsolationSegment, error)
 	ListOrgsForIsolationSegments(guid string) ([]Org, error)
+	ListSpacesForIsolationSegment(guid string) ([]Space, error)
 	DeleteIsolationSegmentByGUID(guid string) error
 	AddIsolationSegmentToOrg(isolationSegmentGUID, orgGUID string) error
 	RemoveIsolationSegmentFromOrg(isolationSegmentGUID, orgGUID string) error

--- a/client_interface.go
+++ b/client_interface.go
@@ -44,6 +44,7 @@ type CloudFoundryClient interface {
 	GetIsolationSegmentByGUID(guid string) (*IsolationSegment, error)
 	ListIsolationSegmentsByQuery(query url.Values) ([]IsolationSegment, error)
 	ListIsolationSegments() ([]IsolationSegment, error)
+	ListOrgsForIsolationSegments(guid string) ([]Org, error)
 	DeleteIsolationSegmentByGUID(guid string) error
 	AddIsolationSegmentToOrg(isolationSegmentGUID, orgGUID string) error
 	RemoveIsolationSegmentFromOrg(isolationSegmentGUID, orgGUID string) error

--- a/isolationsegments.go
+++ b/isolationsegments.go
@@ -142,7 +142,6 @@ func (c *Client) ListIsolationSegments() ([]IsolationSegment, error) {
 	return c.ListIsolationSegmentsByQuery(nil)
 }
 
-// TODO setDefaultIsolationSegmentForOrg
 func (c *Client) ListOrgsForIsolationSegment(guid string) ([]Org, error) {
 	var orgs []Org
 	requestURL := fmt.Sprintf("/v3/isolation_segments/%s/organizations", guid)

--- a/isolationsegments_test.go
+++ b/isolationsegments_test.go
@@ -131,6 +131,27 @@ func TestDeleteIsolationSegmentByGUID(t *testing.T) {
 	})
 }
 
+func TestListOrgsForIsolationSegments(t *testing.T) {
+	Convey("List Orgs entitled for the isolation segment", t, func() {
+		setup(MockRoute{"GET", "/v3/isolation_segments/323f211e-fea3-4161-9bd1-615392327913/organizations", listOrgsForIsolationSegmentPayload, "", http.StatusOK, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		orgs, err := client.ListOrgsForIsolationSegment("323f211e-fea3-4161-9bd1-615392327913")
+		So(err, ShouldBeNil)
+
+		So(orgs[0].Guid, ShouldEqual, "a537761f-9d93-4b30-af17-3d73dbca181b")
+		So(orgs[0].Name, ShouldEqual, "demo")
+		So(orgs[1].Guid, ShouldEqual, "b58e01ea-4919-467b-8249-a910cbdfff8d")
+		So(orgs[1].Name, ShouldEqual, "dev")
+	})
+}
+
 func TestIsolationSegmentMethods(t *testing.T) {
 
 	postData := `{"data":[{"guid":"theKittenIsTheShark"}]}`

--- a/isolationsegments_test.go
+++ b/isolationsegments_test.go
@@ -152,6 +152,29 @@ func TestListOrgsForIsolationSegments(t *testing.T) {
 	})
 }
 
+func TestListSpacesForIsolationSegments(t *testing.T) {
+	Convey("List Spaces entitled for the isolation segment", t, func() {
+		mocks := []MockRoute{
+			{"GET", "/v3/isolation_segments/323f211e-fea3-4161-9bd1-615392327913/relationships/spaces", listSpacesForIsolationSegmentPayload, "", http.StatusOK, "", nil},
+			{"GET", "/v2/spaces/8efd7c5c-d83c-4786-b399-b7bd548839e1", spaceByGuidPayload, "", http.StatusOK, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		spaces, err := client.ListSpacesForIsolationSegment("323f211e-fea3-4161-9bd1-615392327913")
+		So(err, ShouldBeNil)
+
+		So(spaces[0].Guid, ShouldEqual, "8efd7c5c-d83c-4786-b399-b7bd548839e1")
+		So(spaces[0].Name, ShouldEqual, "dev")
+	})
+}
+
 func TestIsolationSegmentMethods(t *testing.T) {
 
 	postData := `{"data":[{"guid":"theKittenIsTheShark"}]}`

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -3075,6 +3075,47 @@ const createIsolationSegmentPayload = `{
    }
 }`
 
+const listOrgsForIsolationSegmentPayload = `{
+   "pagination": {
+      "total_results": 4,
+      "total_pages": 2,
+      "first": {
+         "href": "https://api.example.org/v3/isolation_segments/323f211e-fea3-4161-9bd1-615392327913/organizations?page=1&per_page=2"
+      },
+      "last": {
+         "href": "https://api.example.org/v3/isolation_segments/323f211e-fea3-4161-9bd1-615392327913/organizations?page=2&per_page=2"
+      },
+      "next": {
+			  "href": "https://api.example.org/v3/isolation_segments/323f211e-fea3-4161-9bd1-615392327913/organizationsPage2?page=2&per_page=2"
+			},
+      "previous": null
+   },
+   "resources": [
+      {
+         "guid": "a537761f-9d93-4b30-af17-3d73dbca181b",
+         "name": "demo",
+         "created_at": "2017-04-02T11:22:04Z",
+         "updated_at": "2017-04-02T11:22:04Z",
+         "links": {
+            "self": {
+               "href": "https://api.example.org/v3/organizations/a537761f-9d93-4b30-af17-3d73dbca181b"
+            }
+         }
+      },
+      {
+         "guid": "b58e01ea-4919-467b-8249-a910cbdfff8d",
+         "name": "dev",
+         "created_at": "2017-10-11T13:22:24Z",
+         "updated_at": "2017-10-11T13:22:24Z",
+         "links": {
+            "self": {
+               "href": "https://api.example.org/v3/organizations/b58e01ea-4919-467b-8249-a910cbdfff8d"
+            }
+         }
+      }
+   ]
+}`
+
 const listIsolationSegmentsPayload = `{
    "pagination": {
       "total_results": 2,

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -3116,6 +3116,19 @@ const listOrgsForIsolationSegmentPayload = `{
    ]
 }`
 
+const listSpacesForIsolationSegmentPayload = `{
+	 "data": [
+      {
+         "guid": "8efd7c5c-d83c-4786-b399-b7bd548839e1"
+      }
+   ],
+   "links": {
+      "self": {
+         "href": "https://api.example.org/v3/isolation_segments/323f211e-fea3-4161-9bd1-615392327913/relationships/spaces"
+      }
+   }
+}`
+
 const listIsolationSegmentsPayload = `{
    "pagination": {
       "total_results": 2,


### PR DESCRIPTION
I've added the following functions to package:
1. ListOrgsForIsolationSegments
1. ListSpacesForIsolationSegment

Related to https://github.com/bosh-prometheus/cf_exporter/issues/27

<details><summary>Tests:</summary>

```
=== RUN   TestUpdateApp

  Update app [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
6 total assertions[0m

--- PASS: TestUpdateApp (0.00s)
=== RUN   TestListAppUsageEvents

  List App Usage Events [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
11 total assertions[0m

--- PASS: TestListAppUsageEvents (0.00s)
=== RUN   TestListAppUsageEventsByQuery

  List App Usage Events [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
16 total assertions[0m

--- PASS: TestListAppUsageEventsByQuery (0.00s)
=== RUN   TestListAppEvents

  List App Events [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
25 total assertions[0m

--- PASS: TestListAppEvents (0.00s)
=== RUN   TestListAppEventsByQuery

  List App Events By Query [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
36 total assertions[0m

--- PASS: TestListAppEventsByQuery (0.00s)
=== RUN   TestListApps

  List Apps [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
69 total assertions[0m

--- PASS: TestListApps (0.00s)
=== RUN   TestListAppsByRoute

  List Apps by Route [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
102 total assertions[0m

--- PASS: TestListAppsByRoute (0.00s)
=== RUN   TestGetAppByGuidNoInlineCall

  App By GUID [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
106 total assertions[0m


  App By GUID with environment variables with different types [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
110 total assertions[0m

--- PASS: TestGetAppByGuidNoInlineCall (0.00s)
=== RUN   TestAppByGuid

  App By GUID [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
114 total assertions[0m


  App By GUID with environment variables with different types [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
118 total assertions[0m

--- PASS: TestAppByGuid (0.00s)
=== RUN   TestGetAppInstances

  App completely running [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
126 total assertions[0m


  App partially running [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
134 total assertions[0m

--- PASS: TestGetAppInstances (0.00s)
=== RUN   TestGetAppStats

  App stats completely running [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
160 total assertions[0m

--- PASS: TestGetAppStats (0.00s)
=== RUN   TestGetAppRoutes

  List app routes [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
170 total assertions[0m

--- PASS: TestGetAppRoutes (0.00s)
=== RUN   TestUploadAppBits

  Upload app bits [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
172 total assertions[0m

--- PASS: TestUploadAppBits (0.00s)
=== RUN   TestGetAppBits

  Get app bits [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
176 total assertions[0m

--- PASS: TestGetAppBits (0.00s)
=== RUN   TestKillAppInstance

  Kills an app instance [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
178 total assertions[0m

--- PASS: TestKillAppInstance (0.00s)
=== RUN   TestAppEnv

  Find app space [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
185 total assertions[0m

--- PASS: TestAppEnv (0.00s)
=== RUN   TestAppSummary

  Get app summary [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
210 total assertions[0m

--- PASS: TestAppSummary (0.00s)
=== RUN   TestAppSpace

  Find app space [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
214 total assertions[0m

--- PASS: TestAppSpace (0.00s)
=== RUN   TestDeleteApps

  Delete app [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
216 total assertions[0m

--- PASS: TestDeleteApps (0.00s)
=== RUN   TestCreateApp

  Delete app [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
221 total assertions[0m

--- PASS: TestCreateApp (0.00s)
=== RUN   TestStartApp

  Start app [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
223 total assertions[0m

--- PASS: TestStartApp (0.00s)
=== RUN   TestStopApp

  Stop app [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
225 total assertions[0m

--- PASS: TestStopApp (0.00s)
=== RUN   TestListBuildpacks

  List buildpack [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
233 total assertions[0m

--- PASS: TestListBuildpacks (0.00s)
=== RUN   TestGetBuildpackByGuid

  A buildpack [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
240 total assertions[0m


  A buildpack with no stack [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
247 total assertions[0m

--- PASS: TestGetBuildpackByGuid (0.00s)
=== RUN   TestUploadBuildpack

  Uploading a buildpack succeeds [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
249 total assertions[0m


  Uploading a buildpack throws an error in the event of failure [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
251 total assertions[0m

--- PASS: TestUploadBuildpack (0.00s)
=== RUN   TestUpdateBuildpack

  Updating a buildpack succeeds [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
253 total assertions[0m


  Updating a buildpack doesn't accidentally unlock, rename, disable, or reorder the buildpack [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
255 total assertions[0m


  Unlocking, disabling, reordering to 0, and removing name from buildpacks is still possible [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
257 total assertions[0m


  Updating a buildpack returns an error in the event of failure [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
259 total assertions[0m


  It is possible to update a buildpack stack from null, to a value [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
261 total assertions[0m


  Updating without a stack specified doesn't change anything [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
263 total assertions[0m

--- PASS: TestUpdateBuildpack (0.01s)
=== RUN   TestCreateBuildpack

  Creating a buildpack succeeds [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
271 total assertions[0m


  Creating a buildpack doesn't accidentally unlock, rename, disable, or reorder the buildpack [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
274 total assertions[0m


  Creating a buildpack as unlocked/disabled/order 0 works [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
277 total assertions[0m


  Creating a buildpack returns an error in the event of failure [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
280 total assertions[0m


  Creating a buildpack fails if the request has no name set [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
283 total assertions[0m

--- PASS: TestCreateBuildpack (0.00s)
=== RUN   TestDeleteBuildpack

  Delete buildpack synchronously [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
285 total assertions[0m


  Delete buildpack asynchronously [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
287 total assertions[0m

--- PASS: TestDeleteBuildpack (0.00s)
=== RUN   TestIsSpaceNotFoundError
=== RUN   TestIsSpaceNotFoundError/std/errors_error
=== RUN   TestIsSpaceNotFoundError/pkg/errors_error
=== RUN   TestIsSpaceNotFoundError/unwrapped_CloudFoundry_error
=== RUN   TestIsSpaceNotFoundError/wrapped_CloudFoundry_error
--- PASS: TestIsSpaceNotFoundError (0.00s)
    --- PASS: TestIsSpaceNotFoundError/std/errors_error (0.00s)
    --- PASS: TestIsSpaceNotFoundError/pkg/errors_error (0.00s)
    --- PASS: TestIsSpaceNotFoundError/unwrapped_CloudFoundry_error (0.00s)
    --- PASS: TestIsSpaceNotFoundError/wrapped_CloudFoundry_error (0.00s)
=== RUN   TestDefaultConfig

  Default config [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
293 total assertions[0m

--- PASS: TestDefaultConfig (0.00s)
=== RUN   TestRemovalofTrailingSlashOnAPIAddress

  Test removal of trailing slash of the API Address [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
295 total assertions[0m

--- PASS: TestRemovalofTrailingSlashOnAPIAddress (0.00s)
=== RUN   TestMakeRequest

  Test making request b [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
298 total assertions[0m

--- PASS: TestMakeRequest (0.00s)
=== RUN   TestMakeRequestFailure

  Test making request b [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
301 total assertions[0m

--- PASS: TestMakeRequestFailure (0.00s)
=== RUN   TestMakeRequestWithTimeout

  Test making request b [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
303 total assertions[0m

--- PASS: TestMakeRequestWithTimeout (0.00s)
=== RUN   TestHTTPErrorHandling

  Test making request b [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
309 total assertions[0m

--- PASS: TestHTTPErrorHandling (0.00s)
=== RUN   TestTokenRefresh

  Test making request [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
311 total assertions[0m

--- PASS: TestTokenRefresh (0.11s)
=== RUN   TestEndpointRefresh

  Test expiring endpoint [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
320 total assertions[0m

--- PASS: TestEndpointRefresh (0.01s)
=== RUN   TestListDomains

  List domains [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
328 total assertions[0m

--- PASS: TestListDomains (0.00s)
=== RUN   TestListSharedDomains

  List shared domains [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
335 total assertions[0m


  List shared domain by guid [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
339 total assertions[0m

--- PASS: TestListSharedDomains (0.00s)
=== RUN   TestGetDomainByName

  Get domain by name [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
343 total assertions[0m


  Get domain by name with an endpoint that returns a 404 [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
345 total assertions[0m


  Get domain by name for a non-existing domain [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
347 total assertions[0m

--- PASS: TestGetDomainByName (0.00s)
=== RUN   TestGetSharedDomainByName

  Get shared domain by name [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
351 total assertions[0m


  Get shared domain by name with an endpoint that returns a 404 [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
353 total assertions[0m


  Get shared domain by name for a non-existing domain [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
355 total assertions[0m

--- PASS: TestGetSharedDomainByName (0.00s)
=== RUN   TestCreateDomain

  Create domain [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
358 total assertions[0m

--- PASS: TestCreateDomain (0.00s)
=== RUN   TestCreateSharedDomain

  Create external shared domain [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
362 total assertions[0m


  Create external shared domain [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
366 total assertions[0m

--- PASS: TestCreateSharedDomain (0.00s)
=== RUN   TestDeleteDomain

  Delete domain [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
368 total assertions[0m

--- PASS: TestDeleteDomain (0.00s)
=== RUN   TestDeleteSharedDomain

  Delete shared domain synchronously [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
370 total assertions[0m


  Delete shared domain synchronously [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
372 total assertions[0m

--- PASS: TestDeleteSharedDomain (0.00s)
=== RUN   TestEnvionmentVariableGroups

  List Running Environment Variable Group [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
376 total assertions[0m


  List Staging Environment Variable Group [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
380 total assertions[0m


  Set Running Environment Variable Group [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
382 total assertions[0m


  Set Staging Environment Variable Group [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
384 total assertions[0m

--- PASS: TestEnvionmentVariableGroups (0.00s)
=== RUN   TestListEvents

  List Events [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
390 total assertions[0m

--- PASS: TestListEvents (0.00s)
=== RUN   TestTotalEvents

  Total Events [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
393 total assertions[0m

--- PASS: TestTotalEvents (0.00s)
=== RUN   TestGetInfo

  Get info [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
396 total assertions[0m

--- PASS: TestGetInfo (0.00s)
=== RUN   TestCreateIsolationSegement

  Create Isolation Segment [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
402 total assertions[0m

--- PASS: TestCreateIsolationSegement (0.00s)
=== RUN   TestGetIsolationSegementByGUID

  Request existing Isolation Segment [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
408 total assertions[0m


  Request non-existing Isolation Segment [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
411 total assertions[0m

--- PASS: TestGetIsolationSegementByGUID (0.00s)
=== RUN   TestListIsolationSegments

  Request list of all Isolation Segments [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
423 total assertions[0m

--- PASS: TestListIsolationSegments (0.00s)
=== RUN   TestDeleteIsolationSegmentByGUID

  Delete an Isolation Segment by GUID [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
426 total assertions[0m

--- PASS: TestDeleteIsolationSegmentByGUID (0.00s)
=== RUN   TestListOrgsForIsolationSegments

  List Orgs entitled for the isolation segment [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
432 total assertions[0m

--- PASS: TestListOrgsForIsolationSegments (0.00s)
=== RUN   TestListSpacesForIsolationSegments

  List Spaces entitled for the isolation segment [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
436 total assertions[0m

--- PASS: TestListSpacesForIsolationSegments (0.00s)
=== RUN   TestIsolationSegmentMethods

  Request list of all Isolation Segments [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
445 total assertions[0m

--- PASS: TestIsolationSegmentMethods (0.00s)
=== RUN   TestListOrgQuotas

  List Org Quotas [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
461 total assertions[0m

--- PASS: TestListOrgQuotas (0.00s)
=== RUN   TestGetOrgQuotaByName

  Get Org Quota By Name [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
476 total assertions[0m

--- PASS: TestGetOrgQuotaByName (0.00s)
=== RUN   TestCreateOrgQuota

  Create Org Quota [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
479 total assertions[0m

--- PASS: TestCreateOrgQuota (0.00s)
=== RUN   TestUpdateOrgQuota

  Create Update Quota [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
482 total assertions[0m

--- PASS: TestUpdateOrgQuota (0.00s)
=== RUN   TestDeleteOrgQuota

  Delete org quota synchronously [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
484 total assertions[0m


  Delete org quota asynchronously [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
486 total assertions[0m

--- PASS: TestDeleteOrgQuota (0.00s)
=== RUN   TestListOrgs

  List Orgs [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
491 total assertions[0m

--- PASS: TestListOrgs (0.00s)
=== RUN   TestListOrgsByQuery

  List Orgs [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
496 total assertions[0m

--- PASS: TestListOrgsByQuery (0.00s)
=== RUN   TestGetOrgByGuid

  Get org by GUID [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
500 total assertions[0m

--- PASS: TestGetOrgByGuid (0.00s)
=== RUN   TestOrgSpaces

  Get spaces by org [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
505 total assertions[0m

--- PASS: TestOrgSpaces (0.00s)
=== RUN   TestListOrgUsers

  Get Org Users for an org [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
510 total assertions[0m

--- PASS: TestListOrgUsers (0.00s)
=== RUN   TestListOrgManagers

  Get Org Managers for an org [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
515 total assertions[0m

--- PASS: TestListOrgManagers (0.00s)
=== RUN   TestListOrgAuditors

  Get Org Auditors for an org [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
520 total assertions[0m

--- PASS: TestListOrgAuditors (0.00s)
=== RUN   TestListBillingManagers

  Get Billing Manager for an org [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
525 total assertions[0m

--- PASS: TestListBillingManagers (0.00s)
=== RUN   TestOrgSummary

  Get org summary [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
537 total assertions[0m

--- PASS: TestOrgSummary (0.00s)
=== RUN   TestOrgQuota

  Get org quota [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
552 total assertions[0m

--- PASS: TestOrgQuota (0.00s)
=== RUN   TestCreateOrg

  Create org [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
555 total assertions[0m

--- PASS: TestCreateOrg (0.00s)
=== RUN   TestUpdateOrg

  Update org [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
558 total assertions[0m

--- PASS: TestUpdateOrg (0.00s)
=== RUN   TestDeleteOrg

  Delete org [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
560 total assertions[0m

--- PASS: TestDeleteOrg (0.00s)
=== RUN   TestAssociateManager

  Associate manager [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
563 total assertions[0m

--- PASS: TestAssociateManager (0.00s)
=== RUN   TestAssociateAuditor

  Associate auditor [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
566 total assertions[0m

--- PASS: TestAssociateAuditor (0.00s)
=== RUN   TestAssociateBillingManager

  Associate billing manager [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
569 total assertions[0m

--- PASS: TestAssociateBillingManager (0.00s)
=== RUN   TestAssociateUser

  Associate user [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
572 total assertions[0m

--- PASS: TestAssociateUser (0.00s)
=== RUN   TestAssociateManagerByUsername

  Associate manager by username [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
575 total assertions[0m

--- PASS: TestAssociateManagerByUsername (0.00s)
=== RUN   TestAssociateManagerByUsernameAndOrigin

  Associate manager by username and origin [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
578 total assertions[0m

--- PASS: TestAssociateManagerByUsernameAndOrigin (0.00s)
=== RUN   TestAssociateAuditorByUsername

  Associate auditor by username [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
581 total assertions[0m

--- PASS: TestAssociateAuditorByUsername (0.00s)
=== RUN   TestAssociateAuditorByUsernameAndOrigin

  Associate auditor by username and origin [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
584 total assertions[0m

--- PASS: TestAssociateAuditorByUsernameAndOrigin (0.00s)
=== RUN   TestAssociateBillingManagerByUsername

  Associate billing manager by username [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
587 total assertions[0m

--- PASS: TestAssociateBillingManagerByUsername (0.00s)
=== RUN   TestAssociateBillingManagerByUsernameAndOrigin

  Associate billing manager by username and origin [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
590 total assertions[0m

--- PASS: TestAssociateBillingManagerByUsernameAndOrigin (0.00s)
=== RUN   TestAssociateUserByUsername

  Associate user by username [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
593 total assertions[0m

--- PASS: TestAssociateUserByUsername (0.00s)
=== RUN   TestAssociateUserByUsernameAndOrigin

  Associate user by username and origin [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
596 total assertions[0m

--- PASS: TestAssociateUserByUsernameAndOrigin (0.00s)
=== RUN   TestRemoveManager

  Remove manager [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
598 total assertions[0m

--- PASS: TestRemoveManager (0.00s)
=== RUN   TestRemoveAuditor

  Remove auditor [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
600 total assertions[0m

--- PASS: TestRemoveAuditor (0.00s)
=== RUN   TestRemoveBillingManager

  Remove billing manager [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
602 total assertions[0m

--- PASS: TestRemoveBillingManager (0.00s)
=== RUN   TestRemoveUser

  Remove user [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
604 total assertions[0m

--- PASS: TestRemoveUser (0.00s)
=== RUN   TestRemoveManagerByUsername

  Remove manager by username [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
606 total assertions[0m

--- PASS: TestRemoveManagerByUsername (0.00s)
=== RUN   TestRemoveManagerByUsernameAndOrigin

  Remove manager by username and origin [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
608 total assertions[0m

--- PASS: TestRemoveManagerByUsernameAndOrigin (0.00s)
=== RUN   TestRemoveAuditorByUsername

  Remove auditor by username [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
610 total assertions[0m

--- PASS: TestRemoveAuditorByUsername (0.00s)
=== RUN   TestRemoveAuditorByUsernameAndOrigin

  Remove auditor by username [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
612 total assertions[0m

--- PASS: TestRemoveAuditorByUsernameAndOrigin (0.00s)
=== RUN   TestRemoveBillingManagerByUsername

  Remove billing manager by username [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
614 total assertions[0m

--- PASS: TestRemoveBillingManagerByUsername (0.00s)
=== RUN   TestRemoveBillingManagerByUsernameAndOrigin

  Remove billing manager by username and origin [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
616 total assertions[0m

--- PASS: TestRemoveBillingManagerByUsernameAndOrigin (0.00s)
=== RUN   TestRemoveUserByUsername

  Remove user by username [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
618 total assertions[0m

--- PASS: TestRemoveUserByUsername (0.00s)
=== RUN   TestRemoveUserByUsernameAndOrigin

  Remove user by username and origin [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
620 total assertions[0m

--- PASS: TestRemoveUserByUsernameAndOrigin (0.00s)
=== RUN   TestListOrgSpaceQuotas

  List Org Space Quotas [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
634 total assertions[0m

--- PASS: TestListOrgSpaceQuotas (0.00s)
=== RUN   TestListOrgPrivateDomains

  List Org Space Quotas [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
637 total assertions[0m

--- PASS: TestListOrgPrivateDomains (0.00s)
=== RUN   TestShareOrgPrivateDomain

  Share Org Private Domain [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
640 total assertions[0m

--- PASS: TestShareOrgPrivateDomain (0.00s)
=== RUN   TestUnshareOrgPrivateDomain

  Unshare Org Private Domain [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
642 total assertions[0m

--- PASS: TestUnshareOrgPrivateDomain (0.00s)
=== RUN   TestDefaultIsolationSegmentForOrg

  set Default IsolationSegment [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
644 total assertions[0m

--- PASS: TestDefaultIsolationSegmentForOrg (0.00s)
=== RUN   TestResetDefaultIsolationSegmentForOrg

  Reset Default IsolationSegment [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
646 total assertions[0m

--- PASS: TestResetDefaultIsolationSegmentForOrg (0.00s)
=== RUN   TestListProcesses

  List Processes [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
649 total assertions[0m

--- PASS: TestListProcesses (0.00s)
=== RUN   TestMappingAppAndRoute

  Mapping app and route [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
654 total assertions[0m

--- PASS: TestMappingAppAndRoute (0.00s)
=== RUN   TestListRouteMappings

  List route mappings [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
663 total assertions[0m

--- PASS: TestListRouteMappings (0.00s)
=== RUN   TestGetRouteMappingByGuid

  Get route mapping by guid [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
668 total assertions[0m

--- PASS: TestGetRouteMappingByGuid (0.00s)
=== RUN   TestDeleteRouteMapping

  Delete route mapping [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
670 total assertions[0m

--- PASS: TestDeleteRouteMapping (0.00s)
=== RUN   TestListRoutes

  List Routes [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
680 total assertions[0m

--- PASS: TestListRoutes (0.00s)
=== RUN   TestCreateRoute

  Create HTTP Route [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
689 total assertions[0m

--- PASS: TestCreateRoute (0.00s)
=== RUN   TestCreateTcpRoute

  Create TCP Route [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
695 total assertions[0m

--- PASS: TestCreateTcpRoute (0.00s)
=== RUN   TestBindRoute

  Bind route 
    When a successful status code is returned [32m✔[0m[32m✔[0m
    When an error status code is returned [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
700 total assertions[0m

--- PASS: TestBindRoute (0.00s)
=== RUN   TestDeleteRoute

  Delete route 
    When a successful status code is returned [32m✔[0m[32m✔[0m
    When an error status code is returned [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
704 total assertions[0m

--- PASS: TestDeleteRoute (0.00s)
=== RUN   TestListSecGroups

  List SecGroups [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
735 total assertions[0m

--- PASS: TestListSecGroups (0.00s)
=== RUN   TestSecGroupListSpaceResources

  List Space Resources [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
746 total assertions[0m

--- PASS: TestSecGroupListSpaceResources (0.00s)
=== RUN   TestBindStagingSecGroupToSpaces

  Associate a security group to a space for staging [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
748 total assertions[0m

--- PASS: TestBindStagingSecGroupToSpaces (0.00s)
=== RUN   TestNegativeBindStagingSecGroupToSpaces

  Try to associate a security group to a space for staging on a pre-2.68.0 API [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
750 total assertions[0m

--- PASS: TestNegativeBindStagingSecGroupToSpaces (0.00s)
=== RUN   TestListRunningSecGroups

  List Running SecGroups [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
754 total assertions[0m

--- PASS: TestListRunningSecGroups (0.00s)
=== RUN   TestListStagingSecGroups

  List Staging SecGroups [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
758 total assertions[0m

--- PASS: TestListStagingSecGroups (0.00s)
=== RUN   TestBindRunningSecGroups

  Unbind Running Sec Groups [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
760 total assertions[0m

--- PASS: TestBindRunningSecGroups (0.00s)
=== RUN   TestUnbindRunningSecGroups

  Unbind Running Sec Groups [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
762 total assertions[0m

--- PASS: TestUnbindRunningSecGroups (0.00s)
=== RUN   TestBindStagingSecGroups

  Unbind Staging Sec Groups [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
764 total assertions[0m

--- PASS: TestBindStagingSecGroups (0.00s)
=== RUN   TestUnbindStagingSecGroups

  Unbind Staging Sec Groups [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
766 total assertions[0m

--- PASS: TestUnbindStagingSecGroups (0.00s)
=== RUN   TestListServiceBindings

  List Service Bindings [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
791 total assertions[0m

--- PASS: TestListServiceBindings (0.00s)
=== RUN   TestServiceBindingByGuid

  Service Binding By Guid [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
795 total assertions[0m

--- PASS: TestServiceBindingByGuid (0.00s)
=== RUN   TestDeleteServiceBinding

  Delete service binding [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
797 total assertions[0m

--- PASS: TestDeleteServiceBinding (0.00s)
=== RUN   TestCreateServiceBinding

  Create service binding [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
802 total assertions[0m

--- PASS: TestCreateServiceBinding (0.00s)
=== RUN   TestCreateRouteServiceBinding

  Create route service binding [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
804 total assertions[0m

--- PASS: TestCreateRouteServiceBinding (0.00s)
=== RUN   TestDeleteRouteServiceBinding

  Delete route service binding [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
806 total assertions[0m

--- PASS: TestDeleteRouteServiceBinding (0.00s)
=== RUN   TestListServiceBrokers

  List Service Brokers [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
815 total assertions[0m

--- PASS: TestListServiceBrokers (0.00s)
=== RUN   TestListServicesInstances

  List Service Instances [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
820 total assertions[0m

--- PASS: TestListServicesInstances (0.00s)
=== RUN   TestServiceInstanceByGuid

  Service instance by Guid [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
823 total assertions[0m

--- PASS: TestServiceInstanceByGuid (0.00s)
=== RUN   TestCreateServiceInstance

  Create service instance [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
826 total assertions[0m

--- PASS: TestCreateServiceInstance (0.00s)
=== RUN   TestUpdateServiceInstance

  Update service instance [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
828 total assertions[0m

--- PASS: TestUpdateServiceInstance (0.00s)
=== RUN   TestDeleteServiceInstance

  Delete service instance [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
830 total assertions[0m

--- PASS: TestDeleteServiceInstance (0.00s)
=== RUN   TestListServiceKeys

  List Service Keys [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
855 total assertions[0m

--- PASS: TestListServiceKeys (0.00s)
=== RUN   TestGetServiceKeyByName

  Get service key by name [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
862 total assertions[0m

--- PASS: TestGetServiceKeyByName (0.00s)
=== RUN   TestGetServiceKeyByGuid

  Get service key by guid [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
869 total assertions[0m

--- PASS: TestGetServiceKeyByGuid (0.00s)
=== RUN   TestGetServiceKeysByGuid

  Get service key by guid [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
880 total assertions[0m

--- PASS: TestGetServiceKeysByGuid (0.00s)
=== RUN   TestCreateServiceKey

  Create a service key succeeds [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
884 total assertions[0m


  Create a service key with parameters succeeds [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
886 total assertions[0m


  Delete a service key succeeds [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
888 total assertions[0m


  Create a duplicate service key [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
891 total assertions[0m


  Gets a bad JSON response [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
894 total assertions[0m


  Gets an unexpected HTTP status code [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
897 total assertions[0m

--- PASS: TestCreateServiceKey (0.00s)
=== RUN   TestListServicePlanVisibilities

  List service plan visibilities [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
905 total assertions[0m

--- PASS: TestListServicePlanVisibilities (0.00s)
=== RUN   TestCreateServicePlanVisibility

  Create service plan visibility [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
912 total assertions[0m

--- PASS: TestCreateServicePlanVisibility (0.00s)
=== RUN   TestListServicePlans

  List Service Plans [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
926 total assertions[0m

--- PASS: TestListServicePlans (0.00s)
=== RUN   TestGetServicePlanByGuid

  List Service Plans [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
939 total assertions[0m

--- PASS: TestGetServicePlanByGuid (0.00s)
=== RUN   TestMakeServicePlanPublic

  Make Service Plan public [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
943 total assertions[0m

--- PASS: TestMakeServicePlanPublic (0.00s)
=== RUN   TestMakeServicePlanPrivate

  Make Service Plan private [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
947 total assertions[0m

--- PASS: TestMakeServicePlanPrivate (0.00s)
=== RUN   TestListServiceUsageEvents

  List Service Usage Events [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
952 total assertions[0m

--- PASS: TestListServiceUsageEvents (0.00s)
=== RUN   TestListServiceUsageEventsByQuery

  List Service Usage Events [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
957 total assertions[0m

--- PASS: TestListServiceUsageEventsByQuery (0.00s)
=== RUN   TestListServices

  List Services [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
978 total assertions[0m

--- PASS: TestListServices (0.00s)
=== RUN   TestGetServiceByGuid

  Get Service By Guid [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
986 total assertions[0m

--- PASS: TestGetServiceByGuid (0.00s)
=== RUN   TestListSpaceQuotas

  List Space Quotas [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1000 total assertions[0m

--- PASS: TestListSpaceQuotas (0.00s)
=== RUN   TestGetSpaceQuotaByName

  Get Space Quota By Name [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1013 total assertions[0m

--- PASS: TestGetSpaceQuotaByName (0.00s)
=== RUN   TestCreateSpaceQuota

  Create Space Quota [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1017 total assertions[0m

--- PASS: TestCreateSpaceQuota (0.00s)
=== RUN   TestUpdateSpaceQuota

  Create Update Quota [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1021 total assertions[0m

--- PASS: TestUpdateSpaceQuota (0.00s)
=== RUN   TestAssignSpaceQuota

  Assign Space Quota [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1023 total assertions[0m

--- PASS: TestAssignSpaceQuota (0.00s)
=== RUN   TestListSpaces

  List Space [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1046 total assertions[0m

--- PASS: TestListSpaces (0.00s)
=== RUN   TestListSpaceSecGroups

  List Space SecGroups [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1077 total assertions[0m

--- PASS: TestListSpaceSecGroups (0.00s)
=== RUN   TestListSpaceManagers

  ListSpaceManagers() [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1082 total assertions[0m

--- PASS: TestListSpaceManagers (0.00s)
=== RUN   TestListSpaceAuditors

  ListSpaceAuditors() [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1087 total assertions[0m

--- PASS: TestListSpaceAuditors (0.00s)
=== RUN   TestListSpaceDevelopers

  ListSpaceDevelopers() [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1092 total assertions[0m

--- PASS: TestListSpaceDevelopers (0.00s)
=== RUN   TestCreateSpace

  Create Space [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1097 total assertions[0m

--- PASS: TestCreateSpace (0.00s)
=== RUN   TestUpdateSpace

  Update Space [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1103 total assertions[0m

--- PASS: TestUpdateSpace (0.00s)
=== RUN   TestDeleteSpace

  Delete space [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1105 total assertions[0m

--- PASS: TestDeleteSpace (0.00s)
=== RUN   TestSpaceOrg

  Find space org [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1109 total assertions[0m

--- PASS: TestSpaceOrg (0.00s)
=== RUN   TestSpaceQuota

  Get space quota [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1122 total assertions[0m

--- PASS: TestSpaceQuota (0.00s)
=== RUN   TestSpaceSummary

  Get space summary [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1154 total assertions[0m

--- PASS: TestSpaceSummary (0.00s)
=== RUN   TestSpaceRoles

  Get space roles [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1170 total assertions[0m

--- PASS: TestSpaceRoles (0.00s)
=== RUN   TestAssociateSpaceAuditorByUsername

  Associate auditor by username [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1173 total assertions[0m

--- PASS: TestAssociateSpaceAuditorByUsername (0.00s)
=== RUN   TestAssociateSpaceAuditorByUsernameAndOrigin

  Associate auditor by username and origin [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1176 total assertions[0m

--- PASS: TestAssociateSpaceAuditorByUsernameAndOrigin (0.00s)
=== RUN   TestAssociateSpaceDeveloperByUsername

  Associate developer by username [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1179 total assertions[0m

--- PASS: TestAssociateSpaceDeveloperByUsername (0.00s)
=== RUN   TestAssociateSpaceDeveloperByUsernameAndOrigin

  Associate developer by username and origin [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1182 total assertions[0m

--- PASS: TestAssociateSpaceDeveloperByUsernameAndOrigin (0.00s)
=== RUN   TestAssociateSpaceManagerByUsername

  Associate manager by username [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1185 total assertions[0m

--- PASS: TestAssociateSpaceManagerByUsername (0.00s)
=== RUN   TestAssociateSpaceManagerByUsernameAndOrigin

  Associate manager by username and origin [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1188 total assertions[0m

--- PASS: TestAssociateSpaceManagerByUsernameAndOrigin (0.00s)
=== RUN   TestRemoveSpaceDeveloperByUsername

  Remove developer by username [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1190 total assertions[0m

--- PASS: TestRemoveSpaceDeveloperByUsername (0.00s)
=== RUN   TestRemoveSpaceDeveloperByUsernameAndOrigin

  Remove developer by username and origin [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1192 total assertions[0m

--- PASS: TestRemoveSpaceDeveloperByUsernameAndOrigin (0.00s)
=== RUN   TestRemoveSpaceAuditorByUsername

  Remove auditor by username [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1194 total assertions[0m

--- PASS: TestRemoveSpaceAuditorByUsername (0.00s)
=== RUN   TestRemoveSpaceAuditorByUsernameAndOrigin

  Remove auditor by username and origin [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1196 total assertions[0m

--- PASS: TestRemoveSpaceAuditorByUsernameAndOrigin (0.00s)
=== RUN   TestRemoveSpaceManagerByUsername

  Remove manager by username [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1198 total assertions[0m

--- PASS: TestRemoveSpaceManagerByUsername (0.00s)
=== RUN   TestRemoveSpaceManagerByUsernameAndOrigin

  Remove manager by username and origin [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1200 total assertions[0m

--- PASS: TestRemoveSpaceManagerByUsernameAndOrigin (0.00s)
=== RUN   TestGetSpaceByGuid

  List Space [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1204 total assertions[0m

--- PASS: TestGetSpaceByGuid (0.00s)
=== RUN   TestGetSpaceServiceOfferings

  Get service offerings for space [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1207 total assertions[0m

--- PASS: TestGetSpaceServiceOfferings (0.00s)
=== RUN   TestIsolationSegmentForSpace

  set Default IsolationSegment [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1209 total assertions[0m

--- PASS: TestIsolationSegmentForSpace (0.00s)
=== RUN   TestResetIsolationSegmentForSpace

  Reset IsolationSegment [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1211 total assertions[0m

--- PASS: TestResetIsolationSegmentForSpace (0.00s)
=== RUN   TestListStacks

  List Stacks [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1217 total assertions[0m

--- PASS: TestListStacks (0.00s)
=== RUN   TestListTasks

  List Tasks [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1232 total assertions[0m

--- PASS: TestListTasks (0.00s)
=== RUN   TestListTasksByQuery

  List Tasks [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1247 total assertions[0m

--- PASS: TestListTasksByQuery (0.00s)
=== RUN   TestCreateTask

  Create Task [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1254 total assertions[0m

--- PASS: TestCreateTask (0.00s)
=== RUN   TestCreateTaskFails

  Create Task fails [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1257 total assertions[0m

--- PASS: TestCreateTaskFails (0.00s)
=== RUN   TestTerminateTask

  Terminate Task [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1259 total assertions[0m

--- PASS: TestTerminateTask (0.00s)
=== RUN   TestGetTask

  Create Task [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1266 total assertions[0m

--- PASS: TestGetTask (0.00s)
=== RUN   TestTasksByApp

  List Tasks by App [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1281 total assertions[0m

--- PASS: TestTasksByApp (0.00s)
=== RUN   TestTasksByAppByQuery

  List Tasks by App [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1296 total assertions[0m

--- PASS: TestTasksByAppByQuery (0.00s)
=== RUN   TestUserProvidedServiceInstanceByGuid

  Service instance by Guid [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1308 total assertions[0m

--- PASS: TestUserProvidedServiceInstanceByGuid (0.00s)
=== RUN   TestListUserProvidedServiceInstances

  List Service Instances [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1320 total assertions[0m

--- PASS: TestListUserProvidedServiceInstances (0.00s)
=== RUN   TestCreateUserProvidedServiceInstance

  Create User Provided Service Instance [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1326 total assertions[0m

--- PASS: TestCreateUserProvidedServiceInstance (0.00s)
=== RUN   TestDeleteUserProvidedServiceInstance

  Delete User Provided Service Instance [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1328 total assertions[0m

--- PASS: TestDeleteUserProvidedServiceInstance (0.00s)
=== RUN   TestUpdateUserProvidedServiceInstance

  Update User Provided Service Instance [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1334 total assertions[0m

--- PASS: TestUpdateUserProvidedServiceInstance (0.00s)
=== RUN   TestGetUserByGUID

  Get user by GUID [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1338 total assertions[0m

--- PASS: TestGetUserByGUID (0.00s)
=== RUN   TestListUsers

  List Users [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1349 total assertions[0m

--- PASS: TestListUsers (0.00s)
=== RUN   TestListUserSpaces

  List User Spaces [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1355 total assertions[0m

--- PASS: TestListUserSpaces (0.00s)
=== RUN   TestListUserManagedSpaces

  List User Audited Spaces [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1361 total assertions[0m

--- PASS: TestListUserManagedSpaces (0.00s)
=== RUN   TestListUserAuditedSpaces

  List User Managed Spaces [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1367 total assertions[0m

--- PASS: TestListUserAuditedSpaces (0.00s)
=== RUN   TestListUserOrgs

  List User Spaces [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1373 total assertions[0m

--- PASS: TestListUserOrgs (0.00s)
=== RUN   TestListUserManagedOrgs

  List User Spaces [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1379 total assertions[0m

--- PASS: TestListUserManagedOrgs (0.00s)
=== RUN   TestUserBillingManagedOrgs

  List User Managed Spaces [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1385 total assertions[0m

--- PASS: TestUserBillingManagedOrgs (0.00s)
=== RUN   TestGetUserByUsername

  Get User by Username [32m✔[0m[32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1389 total assertions[0m

--- PASS: TestGetUserByUsername (0.00s)
=== RUN   TestCreateUser

  Create user [32m✔[0m[32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1392 total assertions[0m

--- PASS: TestCreateUser (0.00s)
=== RUN   TestDeleteUser

  Delete user [32m✔[0m[32m✔[0m

[31m[0m[33m[0m[32m
1394 total assertions[0m

--- PASS: TestDeleteUser (0.00s)
PASS
ok  	github.com/cloudfoundry-community/go-cfclient	0.335s

```

</details>