### PR TITLE
Add missing `metadata` field to Event

### DIFF
--- a/events.go
+++ b/events.go
@@ -24,18 +24,19 @@ type EventResource struct {
 
 // Event is a type that contains event data.
 type Event struct {
-	GUID             string `json:"guid"`
-	Type             string `json:"type"`
-	CreatedAt        string `json:"created_at"`
-	Actor            string `json:"actor"`
-	ActorType        string `json:"actor_type"`
-	ActorName        string `json:"actor_name"`
-	ActorUsername    string `json:"actor_username"`
-	Actee            string `json:"actee"`
-	ActeeType        string `json:"actee_type"`
-	ActeeName        string `json:"actee_name"`
-	OrganizationGUID string `json:"organization_guid"`
-	SpaceGUID        string `json:"space_guid"`
+	GUID             string                 `json:"guid"`
+	Type             string                 `json:"type"`
+	CreatedAt        string                 `json:"created_at"`
+	Actor            string                 `json:"actor"`
+	ActorType        string                 `json:"actor_type"`
+	ActorName        string                 `json:"actor_name"`
+	ActorUsername    string                 `json:"actor_username"`
+	Actee            string                 `json:"actee"`
+	ActeeType        string                 `json:"actee_type"`
+	ActeeName        string                 `json:"actee_name"`
+	OrganizationGUID string                 `json:"organization_guid"`
+	SpaceGUID        string                 `json:"space_guid"`
+	Metadata         map[string]interface{} `json:"metadata"`
 	c                *Client
 }
 

--- a/events_test.go
+++ b/events_test.go
@@ -28,6 +28,10 @@ func TestListEvents(t *testing.T) {
 		So(events[0].GUID, ShouldEqual, "b8ede8e1-afc8-40a1-baae-236a0a77b27b")
 		So(events[0].Actor, ShouldEqual, "guid-008640fc-d316-4602-9251-c8d09bbdc750")
 		So(events[0].CreatedAt, ShouldEqual, "2016-06-08T16:41:23Z")
+		So(events[0].Metadata, ShouldHaveLength, 3)
+		So(events[0].Metadata["name-188"], ShouldEqual, "value-188")
+		So(events[0].Metadata["name-189"], ShouldEqual, 189)
+		So(events[0].Metadata["name-190"], ShouldEqual, true)
 	})
 }
 

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -23,7 +23,9 @@ const listEventsPage1Payload = `{
         "actee_name": "name-171",
         "timestamp": "2016-06-08T16:41:23Z",
         "metadata": {
-
+          "name-188": "value-188",
+          "name-189": 189,
+          "name-190": true
         },
         "space_guid": "3a1368e7-e3b7-46af-a98d-57b9c71445e7",
         "organization_guid": "86aa12ee-8c4f-4b26-b391-2be6c1730dbc"


### PR DESCRIPTION
Our `Event` type represents items from [Cloud Controller's `/v2/events` endpoint](https://apidocs.cloudfoundry.org/10.1.0/events/list_all_events.html). There is a `metadata` field missing from our `Event` type. This field is important because it gives more context on what each event did. This PR adds that missing field.

I used `map[string]interface{}` because the values can have varying types. This is [what the CF CLI did](https://github.com/cloudfoundry/cli/blob/c830f550c33a44283780f90f7854e5ed16431d2f/cf/api/resources/events.go#L25).

The test had to workaround that neither `ShouldEqual` or `ShouldResemble` correctly compared that type.