### PR TITLE
Support the "origin" option for password login

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -44,6 +45,11 @@ type Config struct {
 	TokenSource         oauth2.TokenSource
 	tokenSourceDeadline *time.Time
 	UserAgent           string `json:"user_agent"`
+	Origin              string `json:"-"`
+}
+
+type LoginHint struct {
+	Origin string `json:"origin"`
 }
 
 // Request is used to help build up a request
@@ -160,6 +166,16 @@ func getUserAuth(ctx context.Context, config Config, endpoint *Endpoint) (Config
 			AuthURL:  endpoint.AuthEndpoint + "/oauth/auth",
 			TokenURL: endpoint.TokenEndpoint + "/oauth/token",
 		},
+	}
+	if config.Origin != "" {
+		loginHint := LoginHint{config.Origin}
+		origin, err := json.Marshal(loginHint)
+		if err != nil {
+			return config, errors.Wrap(err, "Error creating login_hint")
+		}
+		val := url.Values{}
+		val.Set("login_hint", string(origin))
+		authConfig.Endpoint.TokenURL = fmt.Sprintf("%s?%s", authConfig.Endpoint.TokenURL, val.Encode())
 	}
 
 	token, err := authConfig.PasswordCredentialsToken(ctx, config.Username, config.Password)


### PR DESCRIPTION
Added support for login in with an "origin" option.

Documented at https://docs.cloudfoundry.org/api/uaa/version/74.0.0/index.html#password-grant .

If the Cloud Foundry UAA has multiple identity providers configured, this allows login
in with a specific identity provider.