### PR TITLE
Export fields from Request type to allow mocking

### DIFF
--- a/buildpacks.go
+++ b/buildpacks.go
@@ -56,7 +56,7 @@ func (c *Client) CreateBuildpack(bpr *BuildpackRequest) (*Buildpack, error) {
 	}
 	requestUrl := "/v2/buildpacks"
 	req := c.NewRequest("POST", requestUrl)
-	req.obj = bpr
+	req.Obj = bpr
 	resp, err := c.DoRequest(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error creating buildpack:")
@@ -205,7 +205,7 @@ func (b *Buildpack) Upload(file io.Reader, fileName string) error {
 func (b *Buildpack) Update(bpr *BuildpackRequest) error {
 	requestUrl := fmt.Sprintf("/v2/buildpacks/%s", b.Guid)
 	req := b.c.NewRequest("PUT", requestUrl)
-	req.obj = bpr
+	req.Obj = bpr
 	resp, err := b.c.DoRequest(req)
 	if err != nil {
 		return errors.Wrap(err, "Error updating buildpack:")

--- a/client.go
+++ b/client.go
@@ -48,11 +48,11 @@ type Config struct {
 
 // Request is used to help build up a request
 type Request struct {
-	method string
-	url    string
-	params url.Values
-	body   io.Reader
-	obj    interface{}
+	Method string
+	Url    string
+	Params url.Values
+	Body   io.Reader
+	Obj    interface{}
 }
 
 //DefaultConfig configuration for client
@@ -232,9 +232,9 @@ func getInfo(api string, httpClient *http.Client) (*Endpoint, error) {
 // NewRequest is used to create a new Request
 func (c *Client) NewRequest(method, path string) *Request {
 	r := &Request{
-		method: method,
-		url:    c.Config.ApiAddress + path,
-		params: make(map[string][]string),
+		Method: method,
+		Url:    c.Config.ApiAddress + path,
+		Params: make(map[string][]string),
 	}
 	return r
 }
@@ -245,7 +245,7 @@ func (c *Client) NewRequestWithBody(method, path string, body io.Reader) *Reques
 	r := c.NewRequest(method, path)
 
 	// Set request body
-	r.body = body
+	r.Body = body
 
 	return r
 }
@@ -363,16 +363,16 @@ func (c *Client) refreshEndpoint() error {
 func (r *Request) toHTTP() (*http.Request, error) {
 
 	// Check if we should encode the body
-	if r.body == nil && r.obj != nil {
-		b, err := encodeBody(r.obj)
+	if r.Body == nil && r.Obj != nil {
+		b, err := encodeBody(r.Obj)
 		if err != nil {
 			return nil, err
 		}
-		r.body = b
+		r.Body = b
 	}
 
 	// Create the HTTP Request
-	return http.NewRequest(r.method, r.url, r.body)
+	return http.NewRequest(r.Method, r.Url, r.Body)
 }
 
 // decodeBody is used to JSON decode a body

--- a/client_test.go
+++ b/client_test.go
@@ -66,7 +66,7 @@ func TestMakeRequestFailure(t *testing.T) {
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 		req := client.NewRequest("GET", "/v2/organizations")
-		req.url = "%gh&%ij"
+		req.Url = "%gh&%ij"
 		resp, err := client.DoRequest(req)
 		So(resp, ShouldBeNil)
 		So(err, ShouldNotBeNil)

--- a/domains.go
+++ b/domains.go
@@ -155,7 +155,7 @@ func (c *Client) CreateSharedDomain(name string, internal bool, router_group_gui
 		params["router_group_guid"] = router_group_guid
 	}
 
-	req.obj = params
+	req.Obj = params
 
 	resp, err := c.DoRequest(req)
 	if err != nil {
@@ -217,7 +217,7 @@ func (c *Client) GetSharedDomainByName(name string) (SharedDomain, error) {
 
 func (c *Client) CreateDomain(name, orgGuid string) (*Domain, error) {
 	req := c.NewRequest("POST", "/v2/private_domains")
-	req.obj = map[string]interface{}{
+	req.Obj = map[string]interface{}{
 		"name":                     name,
 		"owning_organization_guid": orgGuid,
 	}

--- a/isolationsegments.go
+++ b/isolationsegments.go
@@ -45,7 +45,7 @@ type ListIsolationSegmentsResponse struct {
 
 func (c *Client) CreateIsolationSegment(name string) (*IsolationSegment, error) {
 	req := c.NewRequest("POST", "/v3/isolation_segments")
-	req.obj = map[string]interface{}{
+	req.Obj = map[string]interface{}{
 		"name": name,
 	}
 	resp, err := c.DoRequest(req)
@@ -189,7 +189,7 @@ func (i *IsolationSegment) AddOrg(orgGuid string) error {
 	type Entry struct {
 		GUID string `json:"guid"`
 	}
-	req.obj = map[string]interface{}{
+	req.Obj = map[string]interface{}{
 		"data": []Entry{{GUID: orgGuid}},
 	}
 	resp, err := i.c.DoRequest(req)
@@ -222,7 +222,7 @@ func (i *IsolationSegment) AddSpace(spaceGuid string) error {
 		return errors.New("No communication handle.")
 	}
 	req := i.c.NewRequest("PUT", fmt.Sprintf("/v2/spaces/%s", spaceGuid))
-	req.obj = map[string]interface{}{
+	req.Obj = map[string]interface{}{
 		"isolation_segment_guid": i.GUID,
 	}
 	resp, err := i.c.DoRequest(req)

--- a/secgroups.go
+++ b/secgroups.go
@@ -532,7 +532,7 @@ func (c *Client) secGroupCreateHelper(url, method, name string, rules []SecGroup
 	if spaceGuids != nil {
 		inputs["space_guids"] = spaceGuids
 	}
-	req.obj = inputs
+	req.Obj = inputs
 	//fire off the request and check for problems
 	resp, err := c.DoRequest(req)
 	if err != nil {

--- a/service_bindings.go
+++ b/service_bindings.go
@@ -121,7 +121,7 @@ func (c *Client) DeleteServiceBinding(guid string) error {
 
 func (c *Client) CreateServiceBinding(appGUID, serviceInstanceGUID string) (*ServiceBinding, error) {
 	req := c.NewRequest("POST", fmt.Sprintf("/v2/service_bindings"))
-	req.obj = map[string]interface{}{
+	req.Obj = map[string]interface{}{
 		"app_guid":              appGUID,
 		"service_instance_guid": serviceInstanceGUID,
 	}

--- a/service_plan_visibilities.go
+++ b/service_plan_visibilities.go
@@ -94,7 +94,7 @@ func (c *Client) CreateServicePlanVisibilityByUniqueId(uniqueId string, organiza
 
 func (c *Client) CreateServicePlanVisibility(servicePlanGuid string, organizationGuid string) (ServicePlanVisibility, error) {
 	req := c.NewRequest("POST", "/v2/service_plan_visibilities")
-	req.obj = map[string]interface{}{
+	req.Obj = map[string]interface{}{
 		"service_plan_guid": servicePlanGuid,
 		"organization_guid": organizationGuid,
 	}
@@ -136,7 +136,7 @@ func (c *Client) DeleteServicePlanVisibility(guid string, async bool) error {
 
 func (c *Client) UpdateServicePlanVisibility(guid string, servicePlanGuid string, organizationGuid string) (ServicePlanVisibility, error) {
 	req := c.NewRequest("PUT", "/v2/service_plan_visibilities/"+guid)
-	req.obj = map[string]interface{}{
+	req.Obj = map[string]interface{}{
 		"service_plan_guid": servicePlanGuid,
 		"organization_guid": organizationGuid,
 	}


### PR DESCRIPTION
## What

This package exposes a `CloudFoundryClient` interface that can be implemented or mocked out. Before this PR the `Request`-based methods are not easy to mock out. The fields on the `Request` struct are all private, and the only information passed to `DoRequest` comes via `Request`. This commit exposes all fields on the `Request` object to make `Request` mocking possible.

## Why

Our https://github.com/alphagov/paas-auditor project uses your library to interact with the CF API. In particular we fetch the previous month of audit events from `/v2/events`.

Your `ListAppEventsByQuery` function does this by loading the entire month of events into memory. On a large platform there can be hundreds of millions of these events across tens of thousands of API pages.

We manually paginate using your `NewRequest` and `DoRequest` functions, but testing this is unpleasant because all fields on `Request` are private and we can't control what gets sent to `DoRequest`.