### PR TITLE
Fix CI: invoke go vet directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
   - FILES=`find . -iname '*.go' -type f -not -path "./vendor/*"`
   # linting
   - gofmt -d $FILES
-  - env GO111MODULE=on go tool vet $FILES
+  - env GO111MODULE=on go vet ./...
   # testing
   - go generate
   - env GO111MODULE=on go test -v -race


### PR DESCRIPTION
We're running on newer Go versions in CI now, so we need to invoke
go vet directly (with a list of packages) rather than running
go tool vet (with a list of files).