### PR TITLE
Add v3 call to get an app's current droplet

### DIFF
--- a/payloads_test.go
+++ b/payloads_test.go
@@ -3511,7 +3511,7 @@ const updateV3AppPayload = `{
   }
 }`
 
-const setCurrentDropletForV3AppPayload = `{
+const currentDropletV3AppPayload = `{
   "data": {
     "guid": "9d8e007c-ce52-4ea7-8a57-f2825d2c6b39"
   },

--- a/v3droplet_test.go
+++ b/v3droplet_test.go
@@ -10,7 +10,7 @@ import (
 func TestSetCurrentDropletForV3App(t *testing.T) {
 	Convey("Set Droplet for V3 App", t, func() {
 		body := `{"data":{"guid":"3fc0916f-2cea-4f3a-ae53-048388baa6bd"}}`
-		setup(MockRoute{"PATCH", "/v3/apps/9d8e007c-ce52-4ea7-8a57-f2825d2c6b39/relationships/current_droplet", setCurrentDropletForV3AppPayload, "", http.StatusOK, "", &body}, t)
+		setup(MockRoute{"PATCH", "/v3/apps/9d8e007c-ce52-4ea7-8a57-f2825d2c6b39/relationships/current_droplet", currentDropletV3AppPayload, "", http.StatusOK, "", &body}, t)
 		defer teardown()
 
 		c := &Config{ApiAddress: server.URL, Token: "foobar"}
@@ -18,6 +18,25 @@ func TestSetCurrentDropletForV3App(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		resp, err := client.SetCurrentDropletForV3App("9d8e007c-ce52-4ea7-8a57-f2825d2c6b39", "3fc0916f-2cea-4f3a-ae53-048388baa6bd")
+		So(err, ShouldBeNil)
+		So(resp, ShouldNotBeNil)
+
+		So(resp.Data.GUID, ShouldEqual, "9d8e007c-ce52-4ea7-8a57-f2825d2c6b39")
+		So(resp.Links["self"].Href, ShouldEqual, "https://api.example.org/v3/apps/d4c91047-7b29-4fda-b7f9-04033e5c9c9f/relationships/current_droplet")
+		So(resp.Links["related"].Href, ShouldEqual, "https://api.example.org/v3/apps/d4c91047-7b29-4fda-b7f9-04033e5c9c9f/droplets/current")
+	})
+}
+
+func TestGetCurrentDropletForV3App(t *testing.T) {
+	Convey("Get Droplet for V3 App", t, func() {
+		setup(MockRoute{"GET", "/v3/apps/9d8e007c-ce52-4ea7-8a57-f2825d2c6b39/relationships/current_droplet", currentDropletV3AppPayload, "", http.StatusOK, "", nil}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		resp, err := client.GetCurrentDropletForV3App("9d8e007c-ce52-4ea7-8a57-f2825d2c6b39")
 		So(err, ShouldBeNil)
 		So(resp, ShouldNotBeNil)
 


### PR DESCRIPTION
This includes a rename of the response for setting an app's current droplet, as the response is shared between the GET/SET calls.  While this rename is a breaking change, it's unlikely to impact anyone who is not actively working with the new code since the existing V3 call was only merged a few days ago.

Closes #259 