### PR TITLE
Use a different call to get v3 app's current droplet

### DIFF
--- a/payloads_test.go
+++ b/payloads_test.go
@@ -3525,6 +3525,66 @@ const currentDropletV3AppPayload = `{
   }
 }`
 
+const getV3CurrentAppDropletPayload = `{
+  "guid": "585bc3c1-3743-497d-88b0-403ad6b56d16",
+  "state": "STAGED",
+  "error": null,
+  "lifecycle": {
+    "type": "buildpack",
+    "data": {}
+  },
+  "execution_metadata": "",
+  "process_types": {
+    "rake": "bundle exec rake",
+    "web": "bundle exec rackup config.ru -p $PORT"
+  },
+  "checksum": {
+    "type": "sha256",
+    "value": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "buildpacks": [
+    {
+      "name": "ruby_buildpack",
+      "detect_output": "ruby 1.6.14",
+      "version": "1.1.1.",
+      "buildpack_name": "ruby"
+    }
+  ],
+  "stack": "cflinuxfs3",
+  "image": null,
+  "created_at": "2016-03-28T23:39:34Z",
+  "updated_at": "2016-03-28T23:39:47Z",
+  "relationships": {
+    "app": {
+      "data": {
+        "guid": "7b34f1cf-7e73-428a-bb5a-8a17a8058396"
+      }
+    }
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/droplets/585bc3c1-3743-497d-88b0-403ad6b56d16"
+    },
+    "package": {
+      "href": "https://api.example.org/v3/packages/8222f76a-9e09-4360-b3aa-1ed329945e92"
+    },
+    "app": {
+      "href": "https://api.example.org/v3/apps/7b34f1cf-7e73-428a-bb5a-8a17a8058396"
+    },
+    "assign_current_droplet": {
+      "href": "https://api.example.org/v3/apps/7b34f1cf-7e73-428a-bb5a-8a17a8058396/relationships/current_droplet",
+      "method": "PATCH"
+      },
+    "download": {
+      "href": "https://api.example.org/v3/droplets/585bc3c1-3743-497d-88b0-403ad6b56d16/download"
+    }
+  },
+  "metadata": {
+    "labels": {},
+    "annotations": {}
+  }
+}`
+
 const listV3AppsPayload = `{
   "pagination": {
     "total_results": 2,

--- a/v3droplet.go
+++ b/v3droplet.go
@@ -71,8 +71,8 @@ func (c *Client) SetCurrentDropletForV3App(appGUID, dropletGUID string) (*Curren
 	return &r, nil
 }
 
-func (c *Client) GetCurrentDropletForV3App(appGUID string) (*CurrentDropletV3Response, error) {
-	req := c.NewRequest("GET", "/v3/apps/"+appGUID+"/relationships/current_droplet")
+func (c *Client) GetCurrentDropletForV3App(appGUID string) (*V3Droplet, error) {
+	req := c.NewRequest("GET", "/v3/apps/"+appGUID+"/droplets/current")
 	resp, err := c.DoRequest(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting droplet for v3 app")
@@ -83,7 +83,7 @@ func (c *Client) GetCurrentDropletForV3App(appGUID string) (*CurrentDropletV3Res
 		return nil, fmt.Errorf("Error getting droplet for v3 app with GUID [%s], response code: %d", appGUID, resp.StatusCode)
 	}
 
-	var r CurrentDropletV3Response
+	var r V3Droplet
 	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
 		return nil, errors.Wrap(err, "Error reading droplet response JSON")
 	}

--- a/v3droplet_test.go
+++ b/v3droplet_test.go
@@ -29,19 +29,20 @@ func TestSetCurrentDropletForV3App(t *testing.T) {
 
 func TestGetCurrentDropletForV3App(t *testing.T) {
 	Convey("Get Droplet for V3 App", t, func() {
-		setup(MockRoute{"GET", "/v3/apps/9d8e007c-ce52-4ea7-8a57-f2825d2c6b39/relationships/current_droplet", currentDropletV3AppPayload, "", http.StatusOK, "", nil}, t)
+		setup(MockRoute{"GET", "/v3/apps/7b34f1cf-7e73-428a-bb5a-8a17a8058396/droplets/current", getV3CurrentAppDropletPayload, "", http.StatusOK, "", nil}, t)
 		defer teardown()
 
 		c := &Config{ApiAddress: server.URL, Token: "foobar"}
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 
-		resp, err := client.GetCurrentDropletForV3App("9d8e007c-ce52-4ea7-8a57-f2825d2c6b39")
+		resp, err := client.GetCurrentDropletForV3App("7b34f1cf-7e73-428a-bb5a-8a17a8058396")
 		So(err, ShouldBeNil)
 		So(resp, ShouldNotBeNil)
 
-		So(resp.Data.GUID, ShouldEqual, "9d8e007c-ce52-4ea7-8a57-f2825d2c6b39")
-		So(resp.Links["self"].Href, ShouldEqual, "https://api.example.org/v3/apps/d4c91047-7b29-4fda-b7f9-04033e5c9c9f/relationships/current_droplet")
-		So(resp.Links["related"].Href, ShouldEqual, "https://api.example.org/v3/apps/d4c91047-7b29-4fda-b7f9-04033e5c9c9f/droplets/current")
+		So(resp.GUID, ShouldEqual, "585bc3c1-3743-497d-88b0-403ad6b56d16")
+		So(resp.Links["self"].Href, ShouldEqual, "https://api.example.org/v3/droplets/585bc3c1-3743-497d-88b0-403ad6b56d16")
+		So(resp.Links["assign_current_droplet"].Href, ShouldEqual, "https://api.example.org/v3/apps/7b34f1cf-7e73-428a-bb5a-8a17a8058396/relationships/current_droplet")
+		So(resp.Links["assign_current_droplet"].Method, ShouldEqual, "PATCH")
 	})
 }


### PR DESCRIPTION
Using `/v3/apps/:guid/droplets/current` gives inline information that has to be fetched in a secondary call when using `/v3/apps/:guid/relationships/current_droplet`.