### PR TITLE
Add basic implementation for v3 organizations

### DIFF
--- a/payloads_test.go
+++ b/payloads_test.go
@@ -3412,6 +3412,194 @@ const createIsolationSegmentPayload = `{
    }
 }`
 
+const listV3OrganizationsPayload = `{
+  "pagination": {
+    "total_results": 2,
+    "total_pages": 2,
+    "first": {
+      "href": "https://api.example.org/v3/organizations?page=1&per_page=1"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/organizations?page=2&per_page=1"
+    },
+    "next": {
+      "href": "https://api.example.org/v3/organizations?page=2&per_page=1"
+    },
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "org-guid",
+      "created_at": "2017-02-01T01:33:58Z",
+      "updated_at": "2017-02-01T01:33:58Z",
+      "name": "my-org-1",
+      "relationships": {
+        "quota": {
+          "data": {
+            "guid": "quota-guid"
+          }
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/organizations/org-guid"
+        },
+        "domains": {
+          "href": "https://api.example.org/v3/organizations/org-guid/domains"
+        },
+        "default_domain": {
+          "href": "https://api.example.org/v3/organizations/org-guid/domains/default"
+        },
+        "quota": {
+          "href": "https://api.example.org/v3/organization_quotas/quota-guid"
+        }
+      },
+      "metadata": {
+        "labels": {},
+        "annotations": {}
+      }
+    }
+  ]
+}`
+
+const listV3OrganizationsPayloadPage2 = `{
+  "pagination": {
+    "total_results": 2,
+    "total_pages": 2,
+    "first": {
+      "href": "https://api.example.org/v3/organizations?page=1&per_page=1"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/organizations?page=2&per_page=1"
+    },
+    "next": null,
+    "previous": {
+      "href": "https://api.example.org/v3/organizations?page=2&per_page=1"
+    }
+  },
+  "resources": [
+    {
+      "guid": "org-guid-2",
+      "created_at": "2017-02-01T01:33:58Z",
+      "updated_at": "2017-02-01T01:33:58Z",
+      "name": "my-org-2",
+      "relationships": {
+        "quota": {
+          "data": null
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/organizations/org-guid-2"
+        },
+        "domains": {
+          "href": "https://api.example.org/v3/organizations/org-guid-2/domains"
+        },
+        "default_domain": {
+          "href": "https://api.example.org/v3/organizations/org-guid-2/domains/default"
+        }
+      },
+      "metadata": {
+        "labels": {},
+        "annotations": {}
+      }
+    }
+  ]
+}`
+
+const updateV3OrganizationPayload = `
+{
+  "guid": "org-guid",
+  "created_at": "2017-02-01T01:33:58Z",
+  "updated_at": "2017-02-01T01:33:58Z",
+  "name": "my-org",
+  "suspended": false,
+  "relationships": {
+    "quota": {
+      "data": null
+    }
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/organizations/org-guid"
+    },
+    "domains": {
+      "href": "https://api.example.org/v3/organizations/org-guid/domains"
+    },
+    "default_domain": {
+      "href": "https://api.example.org/v3/organizations/org-guid/domains/default"
+    }
+  },
+  "metadata": {
+    "labels": {
+      "ORG_KEY": "org_value"
+    },
+    "annotations": {}
+  }
+}`
+
+const getV3OrganizationPayload = `{
+  "guid": "org-guid",
+  "created_at": "2017-02-01T01:33:58Z",
+  "updated_at": "2017-02-01T01:33:58Z",
+  "name": "my-org",
+  "relationships": {
+    "quota": {
+      "data": {
+        "guid": "quota-guid"
+      }
+    }
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/organizations/org-guid"
+    },
+    "domains": {
+      "href": "https://api.example.org/v3/organizations/org-guid/domains"
+    },
+    "default_domain": {
+      "href": "https://api.example.org/v3/organizations/org-guid/domains/default"
+    }
+  },
+  "metadata": {
+    "labels": {
+      "ORG_KEY": "org_value"
+    },
+    "annotations": {}
+  }
+}`
+
+const createV3OrganizationPayload = `{
+  "guid": "org-guid",
+  "created_at": "2017-02-01T01:33:58Z",
+  "updated_at": "2017-02-01T01:33:58Z",
+  "name": "my-org",
+  "relationships": {
+    "quota": {
+      "data": {
+        "guid": "quota-guid"
+      }
+    }
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/organizations/org-guid"
+    },
+    "domains": {
+      "href": "https://api.example.org/v3/organizations/org-guid/domains"
+    },
+    "default_domain": {
+      "href": "https://api.example.org/v3/organizations/org-guid/domains/default"
+    }
+  },
+  "metadata": {
+    "labels": {
+      "ORG_KEY": "org_value"
+    },
+    "annotations": {}
+  }
+}`
+
 const listV3SpacesPayload = `{
   "pagination": {
     "total_results": 2,

--- a/v3organizations.go
+++ b/v3organizations.go
@@ -1,0 +1,178 @@
+package cfclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+type V3Organization struct {
+	Name          string                         `json:"name,omitempty"`
+	GUID          string                         `json:"guid,omitempty"`
+	Suspended     *bool                          `json:"suspended,omitempty"`
+	CreatedAt     string                         `json:"created_at,omitempty"`
+	UpdatedAt     string                         `json:"updated_at,omitempty"`
+	Relationships map[string]V3ToOneRelationship `json:"relationships,omitempty"`
+	Links         map[string]Link                `json:"links,omitempty"`
+	Metadata      V3Metadata                     `json:"metadata,omitempty"`
+}
+
+type CreateV3OrganizationRequest struct {
+	Name      string
+	Suspended *bool `json:"suspended,omitempty"`
+	Metadata  *V3Metadata
+}
+
+type UpdateV3OrganizationRequest struct {
+	Name      string
+	Suspended *bool `json:"suspended,omitempty"`
+	Metadata  *V3Metadata
+}
+
+func (c *Client) CreateV3Organization(r CreateV3OrganizationRequest) (*V3Organization, error) {
+	req := c.NewRequest("POST", "/v3/organizations")
+	params := map[string]interface{}{
+		"name": r.Name,
+	}
+	if r.Suspended != nil {
+		params["suspended"] = r.Suspended
+	}
+	if r.Metadata != nil {
+		params["metadata"] = r.Metadata
+	}
+
+	req.obj = params
+	resp, err := c.DoRequest(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error while creating v3 organization")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("Error creating v3 organization %s, response code: %d", r.Name, resp.StatusCode)
+	}
+
+	var organization V3Organization
+	if err := json.NewDecoder(resp.Body).Decode(&organization); err != nil {
+		return nil, errors.Wrap(err, "Error reading v3 organization JSON")
+	}
+
+	return &organization, nil
+}
+
+func (c *Client) GetV3OrganizationByGUID(organizationGUID string) (*V3Organization, error) {
+	req := c.NewRequest("GET", "/v3/organizations/"+organizationGUID)
+
+	resp, err := c.DoRequest(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error while getting v3 organization")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Error getting v3 organization with GUID [%s], response code: %d", organizationGUID, resp.StatusCode)
+	}
+
+	var organization V3Organization
+	if err := json.NewDecoder(resp.Body).Decode(&organization); err != nil {
+		return nil, errors.Wrap(err, "Error reading v3 organization JSON")
+	}
+
+	return &organization, nil
+}
+
+func (c *Client) DeleteV3Organization(organizationGUID string) error {
+	req := c.NewRequest("DELETE", "/v3/organizations/"+organizationGUID)
+	resp, err := c.DoRequest(req)
+	if err != nil {
+		return errors.Wrap(err, "Error while deleting v3 organization")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("Error deleting v3 organization with GUID [%s], response code: %d", organizationGUID, resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (c *Client) UpdateV3Organization(organizationGUID string, r UpdateV3OrganizationRequest) (*V3Organization, error) {
+	req := c.NewRequest("PATCH", "/v3/organizations/"+organizationGUID)
+	params := make(map[string]interface{})
+	if r.Name != "" {
+		params["name"] = r.Name
+	}
+	if r.Suspended != nil {
+		params["suspended"] = r.Suspended
+	}
+	if r.Metadata != nil {
+		params["metadata"] = r.Metadata
+	}
+	if len(params) > 0 {
+		req.obj = params
+	}
+
+	resp, err := c.DoRequest(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error while updating v3 organization")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Error updating v3 organization %s, response code: %d", organizationGUID, resp.StatusCode)
+	}
+
+	var organization V3Organization
+	if err := json.NewDecoder(resp.Body).Decode(&organization); err != nil {
+		return nil, errors.Wrap(err, "Error reading v3 organization JSON")
+	}
+
+	return &organization, nil
+}
+
+type listV3OrganizationsResponse struct {
+	Pagination Pagination       `json:"pagination,omitempty"`
+	Resources  []V3Organization `json:"resources,omitempty"`
+}
+
+func (c *Client) ListV3OrganizationsByQuery(query url.Values) ([]V3Organization, error) {
+	var organizations []V3Organization
+	requestURL := "/v3/organizations"
+	if e := query.Encode(); len(e) > 0 {
+		requestURL += "?" + e
+	}
+
+	for {
+		r := c.NewRequest("GET", requestURL)
+		resp, err := c.DoRequest(r)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error requesting v3 organizations")
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("Error listing v3 organizations, response code: %d", resp.StatusCode)
+		}
+
+		var data listV3OrganizationsResponse
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return nil, errors.Wrap(err, "Error parsing JSON from list v3 organizations")
+		}
+
+		organizations = append(organizations, data.Resources...)
+
+		requestURL = data.Pagination.Next.Href
+		if requestURL == "" {
+			break
+		}
+		requestURL, err = extractPathFromURL(requestURL)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error parsing the next page request url for v3 organizations")
+		}
+	}
+
+	return organizations, nil
+}

--- a/v3organizations_test.go
+++ b/v3organizations_test.go
@@ -1,0 +1,117 @@
+package cfclient
+
+import (
+	"net/http"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestCreateV3Organization(t *testing.T) {
+	Convey("Create V3 Organization", t, func() {
+		expectedBody := `{"name":"my-org"}`
+		setup(MockRoute{"POST", "/v3/organizations", []string{createV3OrganizationPayload}, "", http.StatusCreated, "", &expectedBody}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		organization, err := client.CreateV3Organization(CreateV3OrganizationRequest{
+			Name: "my-org",
+		})
+		So(err, ShouldBeNil)
+		So(organization, ShouldNotBeNil)
+
+		So(organization.GUID, ShouldEqual, "org-guid")
+		So(organization.Relationships["quota"].Data.GUID, ShouldEqual, "quota-guid")
+		So(organization.Links["domains"].Href, ShouldEqual, "https://api.example.org/v3/organizations/org-guid/domains")
+		So(organization.Metadata.Annotations, ShouldHaveLength, 0)
+		So(organization.Metadata.Labels, ShouldContainKey, "ORG_KEY")
+		So(organization.Metadata.Labels["ORG_KEY"], ShouldEqual, "org_value")
+	})
+}
+
+func TestGetV3Organization(t *testing.T) {
+	Convey("Get V3 Organization", t, func() {
+		setup(MockRoute{"GET", "/v3/organizations/org-guid", []string{getV3OrganizationPayload}, "", http.StatusOK, "", nil}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		organization, err := client.GetV3OrganizationByGUID("org-guid")
+		So(err, ShouldBeNil)
+		So(organization, ShouldNotBeNil)
+
+		So(organization.GUID, ShouldEqual, "org-guid")
+		So(organization.Relationships["quota"].Data.GUID, ShouldEqual, "quota-guid")
+		So(organization.Links["domains"].Href, ShouldEqual, "https://api.example.org/v3/organizations/org-guid/domains")
+		So(organization.Metadata.Annotations, ShouldHaveLength, 0)
+		So(organization.Metadata.Labels, ShouldContainKey, "ORG_KEY")
+		So(organization.Metadata.Labels["ORG_KEY"], ShouldEqual, "org_value")
+	})
+}
+
+func TestDeleteV3Organization(t *testing.T) {
+	Convey("Delete V3 Organization", t, func() {
+		setup(MockRoute{"DELETE", "/v3/organizations/org-guid", []string{""}, "", http.StatusAccepted, "", nil}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		err = client.DeleteV3Organization("org-guid")
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestUpdateV3Organization(t *testing.T) {
+	Convey("Update V3 Organization", t, func() {
+		setup(MockRoute{"PATCH", "/v3/organizations/org-guid", []string{updateV3OrganizationPayload}, "", http.StatusOK, "", nil}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		organization, err := client.UpdateV3Organization("org-guid", UpdateV3OrganizationRequest{
+			Name: "my-org",
+		})
+		So(err, ShouldBeNil)
+		So(organization, ShouldNotBeNil)
+
+		So(organization.Name, ShouldEqual, "my-org")
+		So(organization.GUID, ShouldEqual, "org-guid")
+		So(organization.Relationships["quota"].Data.GUID, ShouldEqual, "")
+		So(organization.Links["domains"].Href, ShouldEqual, "https://api.example.org/v3/organizations/org-guid/domains")
+		So(organization.Metadata.Annotations, ShouldHaveLength, 0)
+		So(organization.Metadata.Labels, ShouldContainKey, "ORG_KEY")
+		So(organization.Metadata.Labels["ORG_KEY"], ShouldEqual, "org_value")
+	})
+}
+
+func TestListV3OrganizationsByQuery(t *testing.T) {
+	Convey("List V3 Organizations", t, func() {
+		setup(MockRoute{"GET", "/v3/organizations", []string{listV3OrganizationsPayload, listV3OrganizationsPayloadPage2}, "", http.StatusOK, "", nil}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		organizations, err := client.ListV3OrganizationsByQuery(nil)
+		So(err, ShouldBeNil)
+		So(organizations, ShouldHaveLength, 2)
+
+		So(organizations[0].Name, ShouldEqual, "my-org-1")
+		So(organizations[1].Name, ShouldEqual, "my-org-2")
+
+		So(organizations[0].Relationships["quota"].Data.GUID, ShouldEqual, "quota-guid")
+		So(organizations[0].Links["domains"].Href, ShouldEqual, "https://api.example.org/v3/organizations/org-guid/domains")
+		So(organizations[1].Relationships["quota"].Data.GUID, ShouldEqual, "")
+		So(organizations[1].Links["domains"].Href, ShouldEqual, "https://api.example.org/v3/organizations/org-guid-2/domains")
+	})
+}


### PR DESCRIPTION
Since I need to be able to get annotations and labels of organizations for a project of mine, I implemented the v3 organizations endpoint.

I did run some basic tests in my sandbox environment but I would appreciate if someone else would review/test it additionally.

Since booleans are kind of difficult to handle in conjunction with `omitempty` and string values don't seem to be accepted by the API, I've used a pointer of type bool for the `suspended` parameter.
That way I am able to check whether it was provided in the request or not.

Please let me know in case something is missing or should be implemented differently.