### PR TITLE
Add paging support to ListByQuery functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![GoDoc](https://godoc.org/github.com/cloudfoundry-community/go-cfclient?status.svg)](http://godoc.org/github.com/cloudfoundry-community/go-cfclient)
 [![Report card](https://goreportcard.com/badge/github.com/cloudfoundry-community/go-cfclient)](https://goreportcard.com/report/github.com/cloudfoundry-community/go-cfclient)
 
-### Overview
+## Overview
 
 `cfclient` is a package to assist you in writing apps that need to interact with [Cloud Foundry](http://cloudfoundry.org).
 It provides functions and structures to retrieve and update
 
 
-### Usage
+## Usage
 
 ```
 go get github.com/cloudfoundry-community/go-cfclient
@@ -43,9 +43,55 @@ func main() {
 }
 ```
 
-### Development
+### Paging Results
 
-#### Errors
+The API supports paging results via query string parameters. All of the v3 ListV3*ByQuery functions support paging. Only a subset of v2 function calls support paging the results:
+
+- ListSpacesByQuery
+- ListOrgsByQuery
+- ListAppsByQuery
+- ListUsersByQuery
+
+You can iterate over the results page-by-page using a function similar to this one:
+
+```go
+func processSpacesOnePageAtATime(client *cfclient.Client) error {
+	page := 1
+	pageSize := 50
+
+	q := url.Values{}
+	q.Add("results-per-page", strconv.Itoa(pageSize))
+
+	for {
+		// get the current page of spaces
+		q.Set("page", strconv.Itoa(page))
+		spaces, err := client.ListSpacesByQuery(q)
+		if err != nil {
+			fmt.Printf("Error getting spaces by query: %s", err)
+			return err
+		}
+
+		// do something with each space
+		fmt.Printf("Page %d:\n", page)
+		for _, s := range spaces {
+			fmt.Println("  " + s.Name)
+		}
+
+		// if we hit an empty page or partial page, that means we're done
+		if len(spaces) < pageSize {
+			break
+		}
+
+		// next page
+		page++
+	}
+	return nil
+}
+```
+
+## Development
+
+### Errors
 
 If the Cloud Foundry error definitions change at <https://github.com/cloudfoundry/cloud_controller_ng/blob/master/vendor/errors/v2.yml>
 then the error predicate functions in this package need to be regenerated.
@@ -56,6 +102,6 @@ To do this, simply use Go to regenerate the code:
 go generate
 ```
 
-### Contributing
+## Contributing
 
 Pull requests welcome.

--- a/apps.go
+++ b/apps.go
@@ -270,11 +270,11 @@ func (a *App) Summary() (AppSummary, error) {
 // less and equal than 0, it queries all app info
 // When there are no more than totalPages apps on server side, all apps info will be returned
 func (c *Client) ListAppsByQueryWithLimits(query url.Values, totalPages int) ([]App, error) {
-	return c.listApps("/v2/apps?"+query.Encode(), totalPages)
+	return c.listApps("/v2/apps", query, totalPages)
 }
 
 func (c *Client) ListAppsByQuery(query url.Values) ([]App, error) {
-	return c.listApps("/v2/apps?"+query.Encode(), -1)
+	return c.listApps("/v2/apps", query, -1)
 }
 
 // GetAppByGuidNoInlineCall will fetch app info including space and orgs information
@@ -327,14 +327,15 @@ func (c *Client) ListApps() ([]App, error) {
 }
 
 func (c *Client) ListAppsByRoute(routeGuid string) ([]App, error) {
-	return c.listApps(fmt.Sprintf("/v2/routes/%s/apps", routeGuid), -1)
+	return c.listApps(fmt.Sprintf("/v2/routes/%s/apps", routeGuid), url.Values{}, -1)
 }
 
 func (c *Client) ListAppsBySpaceGuid(spaceGuid string) ([]App, error) {
-	return c.listApps(fmt.Sprintf("/v2/spaces/%s/apps", spaceGuid), -1)
+	return c.listApps(fmt.Sprintf("/v2/spaces/%s/apps", spaceGuid), url.Values{}, -1)
 }
 
-func (c *Client) listApps(requestUrl string, totalPages int) ([]App, error) {
+func (c *Client) listApps(path string, query url.Values, totalPages int) ([]App, error) {
+	requestUrl := path + "?" + query.Encode()
 	pages := 0
 	apps := []App{}
 	for {
@@ -360,7 +361,7 @@ func (c *Client) listApps(requestUrl string, totalPages int) ([]App, error) {
 		}
 
 		requestUrl = appResp.NextUrl
-		if requestUrl == "" {
+		if requestUrl == "" || query.Get("page") != "" {
 			break
 		}
 

--- a/orgs.go
+++ b/orgs.go
@@ -76,7 +76,7 @@ func (c *Client) ListOrgsByQuery(query url.Values) ([]Org, error) {
 			orgs = append(orgs, c.mergeOrgResource(org))
 		}
 		requestURL = orgResp.NextUrl
-		if requestURL == "" {
+		if requestURL == "" || query.Get("page") != "" {
 			break
 		}
 	}
@@ -121,7 +121,7 @@ func (c *Client) GetOrgByGuid(guid string) (Org, error) {
 }
 
 func (c *Client) OrgSpaces(guid string) ([]Space, error) {
-	return c.fetchSpaces(fmt.Sprintf("/v2/organizations/%s/spaces", guid))
+	return c.fetchSpaces(fmt.Sprintf("/v2/organizations/%s/spaces", guid), url.Values{})
 }
 
 func (o *Org) Summary() (OrgSummary, error) {

--- a/spaces.go
+++ b/spaces.go
@@ -634,18 +634,19 @@ func (s *Space) Update(req SpaceRequest) (Space, error) {
 }
 
 func (c *Client) ListSpacesByQuery(query url.Values) ([]Space, error) {
-	return c.fetchSpaces("/v2/spaces?" + query.Encode())
+	return c.fetchSpaces("/v2/spaces", query)
 }
 
 func (c *Client) ListSpacesByOrgGuid(orgGuid string) ([]Space, error) {
-	return c.fetchSpaces(fmt.Sprintf("/v2/organizations/%s/spaces", orgGuid))
+	return c.fetchSpaces(fmt.Sprintf("/v2/organizations/%s/spaces", orgGuid), url.Values{})
 }
 
 func (c *Client) ListSpaces() ([]Space, error) {
 	return c.ListSpacesByQuery(nil)
 }
 
-func (c *Client) fetchSpaces(requestUrl string) ([]Space, error) {
+func (c *Client) fetchSpaces(path string, query url.Values) ([]Space, error) {
+	requestUrl := path + "?" + query.Encode()
 	var spaces []Space
 	for {
 		spaceResp, err := c.getSpaceResponse(requestUrl)
@@ -656,7 +657,7 @@ func (c *Client) fetchSpaces(requestUrl string) ([]Space, error) {
 			spaces = append(spaces, c.mergeSpaceResource(space))
 		}
 		requestUrl = spaceResp.NextUrl
-		if requestUrl == "" {
+		if requestUrl == "" || query.Get("page") != "" {
 			break
 		}
 	}

--- a/users.go
+++ b/users.go
@@ -85,7 +85,7 @@ func (c *Client) ListUsersByQuery(query url.Values) (Users, error) {
 			users = append(users, user.Entity)
 		}
 		requestUrl = userResp.NextUrl
-		if requestUrl == "" {
+		if requestUrl == "" || query.Get("page") != "" {
 			break
 		}
 	}
@@ -97,15 +97,15 @@ func (c *Client) ListUsers() (Users, error) {
 }
 
 func (c *Client) ListUserSpaces(userGuid string) ([]Space, error) {
-	return c.fetchSpaces(fmt.Sprintf("/v2/users/%s/spaces", userGuid))
+	return c.fetchSpaces(fmt.Sprintf("/v2/users/%s/spaces", userGuid), url.Values{})
 }
 
 func (c *Client) ListUserAuditedSpaces(userGuid string) ([]Space, error) {
-	return c.fetchSpaces(fmt.Sprintf("/v2/users/%s/audited_spaces", userGuid))
+	return c.fetchSpaces(fmt.Sprintf("/v2/users/%s/audited_spaces", userGuid), url.Values{})
 }
 
 func (c *Client) ListUserManagedSpaces(userGuid string) ([]Space, error) {
-	return c.fetchSpaces(fmt.Sprintf("/v2/users/%s/managed_spaces", userGuid))
+	return c.fetchSpaces(fmt.Sprintf("/v2/users/%s/managed_spaces", userGuid), url.Values{})
 }
 
 func (c *Client) ListUserOrgs(userGuid string) ([]Org, error) {

--- a/v3apps.go
+++ b/v3apps.go
@@ -208,7 +208,7 @@ func (c *Client) ListV3AppsByQuery(query url.Values) ([]V3App, error) {
 		apps = append(apps, data.Resources...)
 
 		requestURL = data.Pagination.Next.Href
-		if requestURL == "" {
+		if requestURL == "" || query.Get("page") != "" {
 			break
 		}
 		requestURL, err = extractPathFromURL(requestURL)

--- a/v3organizations.go
+++ b/v3organizations.go
@@ -165,7 +165,7 @@ func (c *Client) ListV3OrganizationsByQuery(query url.Values) ([]V3Organization,
 		organizations = append(organizations, data.Resources...)
 
 		requestURL = data.Pagination.Next.Href
-		if requestURL == "" {
+		if requestURL == "" || query.Get("page") != "" {
 			break
 		}
 		requestURL, err = extractPathFromURL(requestURL)

--- a/v3packages.go
+++ b/v3packages.go
@@ -105,7 +105,7 @@ func (c *Client) ListPackagesForAppV3(appGUID string, query url.Values) ([]V3Pac
 
 		packages = append(packages, data.Resources...)
 		requestURL = data.Pagination.Next.Href
-		if requestURL == "" {
+		if requestURL == "" || query.Get("page") != "" {
 			break
 		}
 		requestURL, err = extractPathFromURL(requestURL)

--- a/v3spaces.go
+++ b/v3spaces.go
@@ -164,7 +164,7 @@ func (c *Client) ListV3SpacesByQuery(query url.Values) ([]V3Space, error) {
 		spaces = append(spaces, data.Resources...)
 
 		requestURL = data.Pagination.Next.Href
-		if requestURL == "" {
+		if requestURL == "" || query.Get("page") != "" {
 			break
 		}
 		requestURL, err = extractPathFromURL(requestURL)


### PR DESCRIPTION
This adds basic paging support to all v3 ListByQuery functions and the major v2 ListByQuery functions and generally fixes #223 

 This implementation is completely backwards compatible and introduces very few code changes. This should allow consumers of this library to implement better feedback/control on foundations with large result sets.

There are a couple of downsides to this implementation that can't easily be addressed without returning a higher level page result/request object:
1. The request params are completely non-typed as url.Values.
2. The calling code has to implicitly break when it encounters a len(result slice) < page size because we don't return any pagination meta data. This means that if you have 100 items and your page size if 50 you will have to make 3 calls to the API with the last result slice being empty. The page sizes aren't likely to fall on a page split boundary, but it could happen and just means an extra wasted round trip to the server.