### PR TITLE
apply golangci lints

### DIFF
--- a/appevents.go
+++ b/appevents.go
@@ -29,7 +29,7 @@ const (
 	FilterActee     = "actee"
 )
 
-//ValidOperators const for all valid operators in a query
+// ValidOperators global variable for all valid operators in a query
 var ValidOperators = []string{":", ">=", "<=", "<", ">", "IN"}
 
 // AppEventResponse the entire response
@@ -47,7 +47,7 @@ type AppEventResource struct {
 	Entity AppEventEntity `json:"entity"`
 }
 
-//AppEventQuery a struct for defining queries like 'q=filter>value' or 'q=filter IN a,b,c'
+// AppEventQuery a struct for defining queries like 'q=filter>value' or 'q=filter IN a,b,c'
 type AppEventQuery struct {
 	Filter   string
 	Operator string
@@ -56,24 +56,24 @@ type AppEventQuery struct {
 
 // The AppEventEntity the actual app event body
 type AppEventEntity struct {
-	//EventTypes are app.crash, audit.app.start, audit.app.stop, audit.app.update, audit.app.create, audit.app.delete-request
+	// EventTypes are app.crash, audit.app.start, audit.app.stop, audit.app.update, audit.app.create, audit.app.delete-request
 	EventType string `json:"type"`
-	//The GUID of the actor.
+	// The GUID of the actor.
 	Actor string `json:"actor"`
-	//The actor type, user or app
+	// The actor type, user or app
 	ActorType string `json:"actor_type"`
-	//The name of the actor.
+	// The name of the actor.
 	ActorName string `json:"actor_name"`
-	//The GUID of the actee.
+	// The GUID of the actee.
 	Actee string `json:"actee"`
-	//The actee type, space, app or v3-app
+	// The actee type, space, app or v3-app
 	ActeeType string `json:"actee_type"`
-	//The name of the actee.
+	// The name of the actee.
 	ActeeName string `json:"actee_name"`
-	//Timestamp format "2016-02-26T13:29:44Z". The event creation time.
+	// Timestamp format "2016-02-26T13:29:44Z". The event creation time.
 	Timestamp time.Time `json:"timestamp"`
 	MetaData  struct {
-		//app.crash event fields
+		// app.crash event fields
 		ExitDescription string `json:"exit_description,omitempty"`
 		ExitReason      string `json:"reason,omitempty"`
 		ExitStatus      string `json:"exit_status,omitempty"`
@@ -85,14 +85,14 @@ type AppEventEntity struct {
 			Memory            float64 `json:"memory,omitempty"`
 			EnvironmentVars   string  `json:"environment_json,omitempty"`
 			DockerCredentials string  `json:"docker_credentials_json,omitempty"`
-			//audit.app.create event fields
+			// audit.app.create event fields
 			Console            bool    `json:"console,omitempty"`
 			Buildpack          string  `json:"buildpack,omitempty"`
 			Space              string  `json:"space_guid,omitempty"`
 			HealthcheckType    string  `json:"health_check_type,omitempty"`
 			HealthcheckTimeout float64 `json:"health_check_timeout,omitempty"`
 			Production         bool    `json:"production,omitempty"`
-			//app.crash event fields
+			// app.crash event fields
 			Index float64 `json:"index,omitempty"`
 		} `json:"request"`
 	} `json:"metadata"`
@@ -114,7 +114,7 @@ func (c *Client) ListAppEventsByQuery(eventType string, queries []AppEventQuery)
 	}
 
 	var query = "/v2/events?q=type:" + eventType
-	//adding the additional queries
+	// adding the additional queries
 	if len(queries) > 0 {
 		for _, eventQuery := range queries {
 			if eventQuery.Filter != FilterTimestamp && eventQuery.Filter != FilterActee {

--- a/appevents.go
+++ b/appevents.go
@@ -8,33 +8,25 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Exported event constants
 const (
-	//AppCrash app.crash event const
-	AppCrash = "app.crash"
-	//AppStart audit.app.start event const
-	AppStart = "audit.app.start"
-	//AppStop audit.app.stop event const
-	AppStop = "audit.app.stop"
-	//AppUpdate audit.app.update event const
-	AppUpdate = "audit.app.update"
-	//AppCreate audit.app.create event const
-	AppCreate = "audit.app.create"
-	//AppDelete audit.app.delete-request event const
-	AppDelete = "audit.app.delete-request"
-	//AppSSHAuth audit.app.ssh-authorized event const
-	AppSSHAuth = "audit.app.ssh-authorized"
-	//AppSSHUnauth audit.app.ssh-unauthorized event const
-	AppSSHUnauth = "audit.app.ssh-unauthorized"
-	//AppRestage audit.app.restage event const
-	AppRestage = "audit.app.restage"
-	//AppMapRoute audit.app.map-route event const
-	AppMapRoute = "audit.app.map-route"
-	//AppUnmapRoute audit.app.unmap-route event const
+	AppCrash      = "app.crash"
+	AppStart      = "audit.app.start"
+	AppStop       = "audit.app.stop"
+	AppUpdate     = "audit.app.update"
+	AppCreate     = "audit.app.create"
+	AppDelete     = "audit.app.delete-request"
+	AppSSHAuth    = "audit.app.ssh-authorized"
+	AppSSHUnauth  = "audit.app.ssh-unauthorized"
+	AppRestage    = "audit.app.restage"
+	AppMapRoute   = "audit.app.map-route"
 	AppUnmapRoute = "audit.app.unmap-route"
-	//FilterTimestamp const for query filter timestamp
+)
+
+// Exported filter constants
+const (
 	FilterTimestamp = "timestamp"
-	//FilterActee const for query filter actee
-	FilterActee = "actee"
+	FilterActee     = "actee"
 )
 
 //ValidOperators const for all valid operators in a query

--- a/apps.go
+++ b/apps.go
@@ -736,6 +736,7 @@ func (c *Client) StopApp(guid string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNoContent {
 		return errors.Wrapf(err, "Error stopping app %s, response code: %d", guid, resp.StatusCode)
 	}

--- a/apps.go
+++ b/apps.go
@@ -371,7 +371,7 @@ func (c *Client) listApps(path string, query url.Values, totalPages int) ([]App,
 			break
 		}
 
-		pages += 1
+		pages++
 		if totalPages > 0 && pages >= totalPages {
 			break
 		}

--- a/apps.go
+++ b/apps.go
@@ -300,7 +300,7 @@ func (c *Client) GetAppByGuidNoInlineCall(guid string) (App, error) {
 
 	// If no Space Information no need to check org.
 	if app.SpaceGuid != "" {
-		//Getting Spaces Resource
+		// Getting Spaces Resource
 		space, err := app.Space()
 		if err != nil {
 			return App{}, errors.Wrap(err, "Unable to get the Space for the app "+app.Name)
@@ -308,7 +308,7 @@ func (c *Client) GetAppByGuidNoInlineCall(guid string) (App, error) {
 			app.SpaceData.Entity = space
 		}
 
-		//Getting orgResource
+		// Getting orgResource
 		org, err := app.SpaceData.Entity.Org()
 		if err != nil {
 			return App{}, errors.Wrap(err, "Unable to get the Org for the app "+app.Name)
@@ -478,7 +478,7 @@ func (c *Client) AppByGuid(guid string) (App, error) {
 	return c.GetAppByGuid(guid)
 }
 
-//AppByName takes an appName, and GUIDs for a space and org, and performs
+// AppByName takes an appName, and GUIDs for a space and org, and performs
 // the API lookup with those query parameters set to return you the desired
 // App object.
 func (c *Client) AppByName(appName, spaceGuid, orgGuid string) (App, error) {

--- a/apps.go
+++ b/apps.go
@@ -194,7 +194,10 @@ func (s *sinceTime) UnmarshalJSON(b []byte) (err error) {
 }
 
 func (s sinceTime) ToTime() time.Time {
-	t, _ := time.Parse(time.UnixDate, s.Format(time.UnixDate))
+	t, err := time.Parse(time.UnixDate, s.Format(time.UnixDate))
+	if err != nil {
+		panic(err)
+	}
 	return t
 }
 
@@ -222,7 +225,10 @@ func (s *statTime) UnmarshalJSON(b []byte) (err error) {
 }
 
 func (s statTime) ToTime() time.Time {
-	t, _ := time.Parse(time.UnixDate, s.Format(time.UnixDate))
+	t, err := time.Parse(time.UnixDate, s.Format(time.UnixDate))
+	if err != nil {
+		panic(err)
+	}
 	return t
 }
 

--- a/apps.go
+++ b/apps.go
@@ -448,7 +448,7 @@ func (c *Client) KillAppInstance(guid string, index string) error {
 		return errors.Wrapf(err, "Error stopping app %s at index %s", guid, index)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 204 {
+	if resp.StatusCode != http.StatusNoContent {
 		return errors.Wrapf(err, "Error stopping app %s at index %s", guid, index)
 	}
 	return nil

--- a/buildpacks.go
+++ b/buildpacks.go
@@ -197,7 +197,7 @@ func (b *Buildpack) Upload(file io.Reader, fileName string) error {
 		req.ContentLength = fileStats.Size()
 		contentType := fmt.Sprintf("multipart/form-data; boundary=%s", writer.Boundary())
 		req.Header.Set("Content-Type", contentType)
-		resp, err := b.c.Do(req) //client.Do() handles the HTTP status code checking for us
+		resp, err := b.c.Do(req) // client.Do() handles the HTTP status code checking for us
 		if err != nil {
 			capturedErr = err
 			return

--- a/cf_test.go
+++ b/cf_test.go
@@ -124,7 +124,8 @@ func setupMultipleWithRedirect(mockEndpoints []MockRouteWithRedirect, t *testing
 		queryString := mock.QueryString
 		postFormBody := mock.PostForm
 		redirectLocation := mock.RedirectLocation
-		if method == "GET" {
+		switch method {
+		case "GET":
 			count := 0
 			r.Get(endpoint, func(res http.ResponseWriter, req *http.Request) (int, string) {
 				testUserAgent(req.Header.Get("User-Agent"), userAgent, t)
@@ -136,34 +137,34 @@ func setupMultipleWithRedirect(mockEndpoints []MockRouteWithRedirect, t *testing
 				count++
 				return status, singleOutput
 			})
-		} else if method == "POST" {
+		case "POST":
 			r.Post(endpoint, func(req *http.Request) (int, string) {
 				testUserAgent(req.Header.Get("User-Agent"), userAgent, t)
 				testQueryString(req.URL.RawQuery, queryString, t)
 				testReqBody(req, postFormBody, t)
 				return status, output[0]
 			})
-		} else if method == "DELETE" {
+		case "DELETE":
 			r.Delete(endpoint, func(req *http.Request) (int, string) {
 				testUserAgent(req.Header.Get("User-Agent"), userAgent, t)
 				testQueryString(req.URL.RawQuery, queryString, t)
 				return status, output[0]
 			})
-		} else if method == "PUT" {
+		case "PUT":
 			r.Put(endpoint, func(req *http.Request) (int, string) {
 				testUserAgent(req.Header.Get("User-Agent"), userAgent, t)
 				testQueryString(req.URL.RawQuery, queryString, t)
 				testReqBody(req, postFormBody, t)
 				return status, output[0]
 			})
-		} else if method == "PATCH" {
+		case "PATCH":
 			r.Patch(endpoint, func(req *http.Request) (int, string) {
 				testUserAgent(req.Header.Get("User-Agent"), userAgent, t)
 				testQueryString(req.URL.RawQuery, queryString, t)
 				testReqBody(req, postFormBody, t)
 				return status, output[0]
 			})
-		} else if method == "PUT-FILE" {
+		case "PUT-FILE":
 			r.Put(endpoint, func(req *http.Request) (int, string) {
 				testUserAgent(req.Header.Get("User-Agent"), userAgent, t)
 				testBodyContains(req, postFormBody, t)

--- a/client.go
+++ b/client.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"time"
 
@@ -78,9 +77,6 @@ type cfHomeConfig struct {
 		Name string
 	}
 	SSLDisabled bool
-
-	mutex sync.RWMutex
-	hc    *http.Client
 }
 
 func NewConfigFromCF() (*Config, error) {

--- a/client.go
+++ b/client.go
@@ -534,6 +534,7 @@ func (c *Client) GetSSHCode() (string, error) {
 	if err == nil {
 		return "", errors.New("authorization server did not redirect with one time code")
 	}
+	defer resp.Body.Close()
 	if netErr, ok := err.(*url.Error); !ok || netErr.Err != ErrPreventRedirect {
 		return "", errors.New(fmt.Sprintf("error requesting one time code from server: %s", err.Error()))
 	}

--- a/client.go
+++ b/client.go
@@ -22,7 +22,7 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 )
 
-//Client used to communicate with Cloud Foundry
+// Client used to communicate with Cloud Foundry
 type Client struct {
 	Config   Config
 	Endpoint Endpoint
@@ -37,7 +37,7 @@ type Endpoint struct {
 	AppSSHOauthClient string `json:"app_ssh_oauth_client"`
 }
 
-//Config is used to configure the creation of a client
+// Config is used to configure the creation of a client
 type Config struct {
 	ApiAddress          string `json:"api_url"`
 	Username            string `json:"user"`

--- a/client_test.go
+++ b/client_test.go
@@ -72,7 +72,7 @@ func TestNewConfigFromCFHome(t *testing.T) {
 		err = os.MkdirAll(configDir, 0744)
 		So(err, ShouldBeNil)
 
-		configPath := path.Join(configDir,  "config.json")
+		configPath := path.Join(configDir, "config.json")
 		err = os.WriteFile(configPath, []byte(cfCLIConfig), 0744)
 		So(err, ShouldBeNil)
 

--- a/domains.go
+++ b/domains.go
@@ -175,6 +175,7 @@ func (c *Client) DeleteSharedDomain(guid string, async bool) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if (async && (resp.StatusCode != http.StatusAccepted)) || (!async && (resp.StatusCode != http.StatusNoContent)) {
 		return errors.Wrapf(err, "Error deleting organization %s, response code: %d", guid, resp.StatusCode)
 	}

--- a/domains.go
+++ b/domains.go
@@ -59,10 +59,10 @@ type SharedDomain struct {
 
 func (c *Client) ListDomainsByQuery(query url.Values) ([]Domain, error) {
 	var domains []Domain
-	requestUrl := "/v2/private_domains?" + query.Encode()
+	requestURL := "/v2/private_domains?" + query.Encode()
 	for {
 		var domainResp DomainsResponse
-		r := c.NewRequest("GET", requestUrl)
+		r := c.NewRequest("GET", requestURL)
 		resp, err := c.DoRequest(r)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error requesting domains")
@@ -84,8 +84,8 @@ func (c *Client) ListDomainsByQuery(query url.Values) ([]Domain, error) {
 			domain.Entity.c = c
 			domains = append(domains, domain.Entity)
 		}
-		requestUrl = domainResp.NextUrl
-		if requestUrl == "" {
+		requestURL = domainResp.NextUrl
+		if requestURL == "" {
 			break
 		}
 	}
@@ -98,10 +98,10 @@ func (c *Client) ListDomains() ([]Domain, error) {
 
 func (c *Client) ListSharedDomainsByQuery(query url.Values) ([]SharedDomain, error) {
 	var domains []SharedDomain
-	requestUrl := "/v2/shared_domains?" + query.Encode()
+	requestURL := "/v2/shared_domains?" + query.Encode()
 	for {
 		var domainResp SharedDomainsResponse
-		r := c.NewRequest("GET", requestUrl)
+		r := c.NewRequest("GET", requestURL)
 		resp, err := c.DoRequest(r)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error requesting shared domains")
@@ -123,8 +123,8 @@ func (c *Client) ListSharedDomainsByQuery(query url.Values) ([]SharedDomain, err
 			domain.Entity.c = c
 			domains = append(domains, domain.Entity)
 		}
-		requestUrl = domainResp.NextUrl
-		if requestUrl == "" {
+		requestURL = domainResp.NextUrl
+		if requestURL == "" {
 			break
 		}
 	}
@@ -278,9 +278,9 @@ func (c *Client) handleSharedDomainResp(resp *http.Response) (*SharedDomain, err
 	return c.mergeSharedDomainResource(domainResource), nil
 }
 
-func (c *Client) getDomainsResponse(requestUrl string) (DomainsResponse, error) {
+func (c *Client) getDomainsResponse(requestURL string) (DomainsResponse, error) {
 	var domainResp DomainsResponse
-	r := c.NewRequest("GET", requestUrl)
+	r := c.NewRequest("GET", requestURL)
 	resp, err := c.DoRequest(r)
 	if err != nil {
 		return DomainsResponse{}, errors.Wrap(err, "Error requesting domains")

--- a/isolationsegments.go
+++ b/isolationsegments.go
@@ -255,6 +255,7 @@ func (i *IsolationSegment) RemoveSpace(spaceGuid string) error {
 	if err != nil {
 		return errors.Wrapf(err, "Error during deleting space %s in isolation segment %s", spaceGuid, i.Name)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("Error deleting space %s from isolation segment %s, response code: %d", spaceGuid, i.Name, resp.StatusCode)
 	}

--- a/org_quotas.go
+++ b/org_quotas.go
@@ -59,9 +59,9 @@ type OrgQuota struct {
 
 func (c *Client) ListOrgQuotasByQuery(query url.Values) ([]OrgQuota, error) {
 	var orgQuotas []OrgQuota
-	requestUrl := "/v2/quota_definitions?" + query.Encode()
+	requestURL := "/v2/quota_definitions?" + query.Encode()
 	for {
-		orgQuotasResp, err := c.getOrgQuotasResponse(requestUrl)
+		orgQuotasResp, err := c.getOrgQuotasResponse(requestURL)
 		if err != nil {
 			return []OrgQuota{}, err
 		}
@@ -72,8 +72,8 @@ func (c *Client) ListOrgQuotasByQuery(query url.Values) ([]OrgQuota, error) {
 			org.Entity.c = c
 			orgQuotas = append(orgQuotas, org.Entity)
 		}
-		requestUrl = orgQuotasResp.NextUrl
-		if requestUrl == "" {
+		requestURL = orgQuotasResp.NextUrl
+		if requestURL == "" {
 			break
 		}
 	}
@@ -97,9 +97,9 @@ func (c *Client) GetOrgQuotaByName(name string) (OrgQuota, error) {
 	return orgQuotas[0], nil
 }
 
-func (c *Client) getOrgQuotasResponse(requestUrl string) (OrgQuotasResponse, error) {
+func (c *Client) getOrgQuotasResponse(requestURL string) (OrgQuotasResponse, error) {
 	var orgQuotasResp OrgQuotasResponse
-	r := c.NewRequest("GET", requestUrl)
+	r := c.NewRequest("GET", requestURL)
 	resp, err := c.DoRequest(r)
 	if err != nil {
 		return OrgQuotasResponse{}, errors.Wrap(err, "Error requesting org quotas")

--- a/orgs.go
+++ b/orgs.go
@@ -839,6 +839,7 @@ func (c *Client) updateOrgDefaultIsolationSegment(orgGUID string, data interface
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return errors.Wrapf(err, "Error setting default isolation segment for org %s, response code: %d", orgGUID, resp.StatusCode)
 	}

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -267,12 +267,6 @@ const getOrgByNamePayload = `{
 ]
 }`
 
-const orgNotFoundPayload = `{
-    "description": "The organization could not be found: 8ad5278f-8f81-47ea-82aa-114c39441bcf",
-    "error_code": "CF-OrganizationNotFound",
-    "code": 30003
-}`
-
 const listOrgPeoplePayload = `
 {
   "total_results": 2,

--- a/resource_match.go
+++ b/resource_match.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-//The Resource match Api retruns the response in the following data structure
+// The Resource match Api retruns the response in the following data structure
 type Resource struct {
 	Sha1 string `json:"sha1"`
 	Size int    `json:"size"`

--- a/secgroups.go
+++ b/secgroups.go
@@ -548,6 +548,7 @@ func (c *Client) secGroupCreateHelper(url, method, name string, rules []SecGroup
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusCreated { // Both create and update should give 201 CREATED
 		var response SecGroupCreateResponse
 

--- a/secgroups.go
+++ b/secgroups.go
@@ -247,7 +247,7 @@ func (secGroup *SecGroup) ListStagingSpaceResources() ([]SpaceResource, error) {
 			// if this is a 404, let's make sure that it's not because we're on a legacy system
 			if cause := errors.Cause(err); cause != nil {
 				if httpErr, ok := cause.(CloudFoundryHTTPError); ok {
-					if httpErr.StatusCode == 404 {
+					if httpErr.StatusCode == http.StatusNotFound {
 						info, infoErr := secGroup.c.GetInfo()
 						if infoErr != nil {
 							return nil, infoErr
@@ -316,7 +316,7 @@ func (c *Client) DeleteSecGroup(guid string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 204 { // 204 No Content
+	if resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -333,7 +333,7 @@ func (c *Client) GetSecGroup(guid string) (*SecGroup, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	// get the json out of the response body
@@ -352,7 +352,7 @@ func (c *Client) BindSecGroup(secGUID, spaceGUID string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 201 { // 201 Created
+	if resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -370,7 +370,7 @@ func (c *Client) BindStagingSecGroupToSpace(secGUID, spaceGUID string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 201 { // 201 Created
+	if resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -387,7 +387,7 @@ func (c *Client) BindRunningSecGroup(secGUID string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 { // 200
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -404,7 +404,7 @@ func (c *Client) UnbindRunningSecGroup(secGUID string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusNoContent { // 204
+	if resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -421,7 +421,7 @@ func (c *Client) BindStagingSecGroup(secGUID string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 { // 200
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -438,7 +438,7 @@ func (c *Client) UnbindStagingSecGroup(secGUID string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusNoContent { // 204
+	if resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -456,7 +456,7 @@ func (c *Client) UnbindSecGroup(secGUID, spaceGUID string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 204 { // 204 No Content
+	if resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -548,7 +548,7 @@ func (c *Client) secGroupCreateHelper(url, method, name string, rules []SecGroup
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode != 201 { // Both create and update should give 201 CREATED
+	if resp.StatusCode != http.StatusCreated { // Both create and update should give 201 CREATED
 		var response SecGroupCreateResponse
 
 		bodyRaw, _ := ioutil.ReadAll(resp.Body)

--- a/secgroups.go
+++ b/secgroups.go
@@ -502,16 +502,16 @@ func convertStructToMap(st interface{}) map[string]interface{} {
 			key = jsonName
 		}
 
-		if typ == "string" {
+		switch typ {
+		case "string":
 			if !(value.String() == "" && strings.Contains(structTag, "omitempty")) {
 				reqRules[key] = value.String()
 			}
-		} else if typ == "int" {
+		case "int":
 			reqRules[key] = value.Int()
-		} else {
+		default:
 			reqRules[key] = value.Interface()
 		}
-
 	}
 
 	return reqRules

--- a/secgroups.go
+++ b/secgroups.go
@@ -48,12 +48,12 @@ type SecGroup struct {
 
 type SecGroupRule struct {
 	Protocol    string `json:"protocol"`
-	Ports       string `json:"ports,omitempty"`       //e.g. "4000-5000,9142"
-	Destination string `json:"destination"`           //CIDR Format
-	Description string `json:"description,omitempty"` //Optional description
+	Ports       string `json:"ports,omitempty"`       // e.g. "4000-5000,9142"
+	Destination string `json:"destination"`           // CIDR Format
+	Description string `json:"description,omitempty"` // Optional description
 	Code        int    `json:"code"`                  // ICMP code
-	Type        int    `json:"type"`                  //ICMP type. Only valid if Protocol=="icmp"
-	Log         bool   `json:"log,omitempty"`         //If true, log this rule
+	Type        int    `json:"type"`                  // ICMP type. Only valid if Protocol=="icmp"
+	Log         bool   `json:"log,omitempty"`         // If true, log this rule
 }
 
 var MinStagingSpacesVersion *semver.Version = getMinStagingSpacesVersion()
@@ -310,13 +310,13 @@ DeleteSecGroup contacts the CF endpoint to delete an existing security group.
 guid: Indentifies the security group to be deleted.
 */
 func (c *Client) DeleteSecGroup(guid string) error {
-	//Perform the DELETE and check for errors
+	// Perform the DELETE and check for errors
 	resp, err := c.DoRequest(c.NewRequest("DELETE", fmt.Sprintf("/v2/security_groups/%s", guid)))
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 204 { //204 No Content
+	if resp.StatusCode != 204 { // 204 No Content
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -327,7 +327,7 @@ GetSecGroup contacts the CF endpoint for fetching the info for a particular secu
 guid: Identifies the security group to fetch information from
 */
 func (c *Client) GetSecGroup(guid string) (*SecGroup, error) {
-	//Perform the GET and check for errors
+	// Perform the GET and check for errors
 	resp, err := c.DoRequest(c.NewRequest("GET", "/v2/security_groups/"+guid))
 	if err != nil {
 		return nil, err
@@ -336,7 +336,7 @@ func (c *Client) GetSecGroup(guid string) (*SecGroup, error) {
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
-	//get the json out of the response body
+	// get the json out of the response body
 	return respBodyToSecGroup(resp.Body, c)
 }
 
@@ -346,13 +346,13 @@ secGUID: identifies the security group to add a space to
 spaceGUID: identifies the space to associate
 */
 func (c *Client) BindSecGroup(secGUID, spaceGUID string) error {
-	//Perform the PUT and check for errors
+	// Perform the PUT and check for errors
 	resp, err := c.DoRequest(c.NewRequest("PUT", fmt.Sprintf("/v2/security_groups/%s/spaces/%s", secGUID, spaceGUID)))
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 201 { //201 Created
+	if resp.StatusCode != 201 { // 201 Created
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -364,13 +364,13 @@ secGUID: identifies the security group to add a space to
 spaceGUID: identifies the space to associate
 */
 func (c *Client) BindStagingSecGroupToSpace(secGUID, spaceGUID string) error {
-	//Perform the PUT and check for errors
+	// Perform the PUT and check for errors
 	resp, err := c.DoRequest(c.NewRequest("PUT", fmt.Sprintf("/v2/security_groups/%s/staging_spaces/%s", secGUID, spaceGUID)))
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 201 { //201 Created
+	if resp.StatusCode != 201 { // 201 Created
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -381,13 +381,13 @@ BindRunningSecGroup contacts the CF endpoint to associate  a security group
 secGUID: identifies the security group to add a space to
 */
 func (c *Client) BindRunningSecGroup(secGUID string) error {
-	//Perform the PUT and check for errors
+	// Perform the PUT and check for errors
 	resp, err := c.DoRequest(c.NewRequest("PUT", fmt.Sprintf("/v2/config/running_security_groups/%s", secGUID)))
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 { //200
+	if resp.StatusCode != 200 { // 200
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -398,13 +398,13 @@ UnbindRunningSecGroup contacts the CF endpoint to dis-associate  a security grou
 secGUID: identifies the security group to add a space to
 */
 func (c *Client) UnbindRunningSecGroup(secGUID string) error {
-	//Perform the DELETE and check for errors
+	// Perform the DELETE and check for errors
 	resp, err := c.DoRequest(c.NewRequest("DELETE", fmt.Sprintf("/v2/config/running_security_groups/%s", secGUID)))
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusNoContent { //204
+	if resp.StatusCode != http.StatusNoContent { // 204
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -415,13 +415,13 @@ BindStagingSecGroup contacts the CF endpoint to associate a space with a securit
 secGUID: identifies the security group to add a space to
 */
 func (c *Client) BindStagingSecGroup(secGUID string) error {
-	//Perform the PUT and check for errors
+	// Perform the PUT and check for errors
 	resp, err := c.DoRequest(c.NewRequest("PUT", fmt.Sprintf("/v2/config/staging_security_groups/%s", secGUID)))
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 { //200
+	if resp.StatusCode != 200 { // 200
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -432,13 +432,13 @@ UnbindStagingSecGroup contacts the CF endpoint to dis-associate a space with a s
 secGUID: identifies the security group to add a space to
 */
 func (c *Client) UnbindStagingSecGroup(secGUID string) error {
-	//Perform the DELETE and check for errors
+	// Perform the DELETE and check for errors
 	resp, err := c.DoRequest(c.NewRequest("DELETE", fmt.Sprintf("/v2/config/staging_security_groups/%s", secGUID)))
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusNoContent { //204
+	if resp.StatusCode != http.StatusNoContent { // 204
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
@@ -450,32 +450,32 @@ secGUID: identifies the security group to remove a space from
 spaceGUID: identifies the space to dissociate from the security group
 */
 func (c *Client) UnbindSecGroup(secGUID, spaceGUID string) error {
-	//Perform the DELETE and check for errors
+	// Perform the DELETE and check for errors
 	resp, err := c.DoRequest(c.NewRequest("DELETE", fmt.Sprintf("/v2/security_groups/%s/spaces/%s", secGUID, spaceGUID)))
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 204 { //204 No Content
+	if resp.StatusCode != 204 { // 204 No Content
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil
 }
 
-//Reads most security group response bodies into a SecGroup object
+// Reads most security group response bodies into a SecGroup object
 func respBodyToSecGroup(body io.ReadCloser, c *Client) (*SecGroup, error) {
-	//get the json from the response body
+	// get the json from the response body
 	bodyRaw, err := ioutil.ReadAll(body)
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not read response body")
 	}
 	jStruct := SecGroupResource{}
-	//make it a SecGroup
+	// make it a SecGroup
 	err = json.Unmarshal(bodyRaw, &jStruct)
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not unmarshal response body as json")
 	}
-	//pull a few extra fields from other places
+	// pull a few extra fields from other places
 	ret := jStruct.Entity
 	ret.Guid = jStruct.Meta.Guid
 	ret.CreatedAt = jStruct.Meta.CreatedAt
@@ -517,7 +517,7 @@ func convertStructToMap(st interface{}) map[string]interface{} {
 	return reqRules
 }
 
-//Create and Update secGroup pretty much do the same thing, so this function abstracts those out.
+// Create and Update secGroup pretty much do the same thing, so this function abstracts those out.
 func (c *Client) secGroupCreateHelper(url, method, name string, rules []SecGroupRule, spaceGuids []string) (*SecGroup, error) {
 	reqRules := make([]map[string]interface{}, len(rules))
 
@@ -533,7 +533,7 @@ func (c *Client) secGroupCreateHelper(url, method, name string, rules []SecGroup
 	}
 
 	req := c.NewRequest(method, url)
-	//set up request body
+	// set up request body
 	inputs := map[string]interface{}{
 		"name":  name,
 		"rules": reqRules,
@@ -543,7 +543,7 @@ func (c *Client) secGroupCreateHelper(url, method, name string, rules []SecGroup
 		inputs["space_guids"] = spaceGuids
 	}
 	req.obj = inputs
-	//fire off the request and check for problems
+	// fire off the request and check for problems
 	resp, err := c.DoRequest(req)
 	if err != nil {
 		return nil, err
@@ -565,7 +565,7 @@ Code        %d
 Description %s`,
 			resp.StatusCode, response.ErrorCode, response.Code, response.Description)
 	}
-	//get the json from the response body
+	// get the json from the response body
 	return respBodyToSecGroup(resp.Body, c)
 }
 

--- a/service_brokers.go
+++ b/service_brokers.go
@@ -58,7 +58,7 @@ func (c *Client) DeleteServiceBroker(guid string) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNoContent {
-		return errors.Wrapf(err, "Error deleteing service broker %s, response code: %d", guid, resp.StatusCode)
+		return errors.Wrapf(err, "Error deleting service broker %s, response code: %d", guid, resp.StatusCode)
 	}
 	return nil
 

--- a/service_brokers.go
+++ b/service_brokers.go
@@ -50,8 +50,8 @@ type ServiceBroker struct {
 }
 
 func (c *Client) DeleteServiceBroker(guid string) error {
-	requestUrl := fmt.Sprintf("/v2/service_brokers/%s", guid)
-	r := c.NewRequest("DELETE", requestUrl)
+	requestURL := fmt.Sprintf("/v2/service_brokers/%s", guid)
+	r := c.NewRequest("DELETE", requestURL)
 	resp, err := c.DoRequest(r)
 	if err != nil {
 		return err
@@ -127,9 +127,9 @@ func (c *Client) CreateServiceBroker(csb CreateServiceBrokerRequest) (ServiceBro
 
 func (c *Client) ListServiceBrokersByQuery(query url.Values) ([]ServiceBroker, error) {
 	var sbs []ServiceBroker
-	requestUrl := "/v2/service_brokers?" + query.Encode()
+	requestURL := "/v2/service_brokers?" + query.Encode()
 	for {
-		serviceBrokerResp, err := c.getServiceBrokerResponse(requestUrl)
+		serviceBrokerResp, err := c.getServiceBrokerResponse(requestURL)
 		if err != nil {
 			return []ServiceBroker{}, err
 		}
@@ -139,8 +139,8 @@ func (c *Client) ListServiceBrokersByQuery(query url.Values) ([]ServiceBroker, e
 			sb.Entity.UpdatedAt = sb.Meta.UpdatedAt
 			sbs = append(sbs, sb.Entity)
 		}
-		requestUrl = serviceBrokerResp.NextUrl
-		if requestUrl == "" {
+		requestURL = serviceBrokerResp.NextUrl
+		if requestURL == "" {
 			break
 		}
 	}
@@ -188,9 +188,9 @@ func (c *Client) GetServiceBrokerByName(name string) (ServiceBroker, error) {
 	return sbs[0], nil
 }
 
-func (c *Client) getServiceBrokerResponse(requestUrl string) (ServiceBrokerResponse, error) {
+func (c *Client) getServiceBrokerResponse(requestURL string) (ServiceBrokerResponse, error) {
 	var serviceBrokerResp ServiceBrokerResponse
-	r := c.NewRequest("GET", requestUrl)
+	r := c.NewRequest("GET", requestURL)
 	resp, err := c.DoRequest(r)
 	if err != nil {
 		return ServiceBrokerResponse{}, errors.Wrap(err, "Error requesting Service Brokers")

--- a/service_plan_visibilities.go
+++ b/service_plan_visibilities.go
@@ -83,7 +83,7 @@ func (c *Client) GetServicePlanVisibilityByGuid(guid string) (ServicePlanVisibil
 	return respBodyToServicePlanVisibility(resp.Body, c)
 }
 
-//a uniqueID is the id of the service in the catalog and not in cf internal db
+// a uniqueID is the id of the service in the catalog and not in cf internal db
 func (c *Client) CreateServicePlanVisibilityByUniqueId(uniqueId string, organizationGuid string) (ServicePlanVisibility, error) {
 	q := url.Values{}
 	q.Set("q", fmt.Sprintf("unique_id:%s", uniqueId))

--- a/service_plans.go
+++ b/service_plans.go
@@ -43,10 +43,10 @@ type ServicePlan struct {
 
 func (c *Client) ListServicePlansByQuery(query url.Values) ([]ServicePlan, error) {
 	var servicePlans []ServicePlan
-	requestUrl := "/v2/service_plans?" + query.Encode()
+	requestURL := "/v2/service_plans?" + query.Encode()
 	for {
 		var servicePlansResp ServicePlansResponse
-		r := c.NewRequest("GET", requestUrl)
+		r := c.NewRequest("GET", requestURL)
 		resp, err := c.DoRequest(r)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error requesting service plans")
@@ -67,8 +67,8 @@ func (c *Client) ListServicePlansByQuery(query url.Values) ([]ServicePlan, error
 			servicePlan.Entity.c = c
 			servicePlans = append(servicePlans, servicePlan.Entity)
 		}
-		requestUrl = servicePlansResp.NextUrl
-		if requestUrl == "" {
+		requestURL = servicePlansResp.NextUrl
+		if requestURL == "" {
 			break
 		}
 	}

--- a/services.go
+++ b/services.go
@@ -90,10 +90,10 @@ func (c *Client) GetServiceByGuid(guid string) (Service, error) {
 
 func (c *Client) ListServicesByQuery(query url.Values) ([]Service, error) {
 	var services []Service
-	requestUrl := "/v2/services?" + query.Encode()
+	requestURL := "/v2/services?" + query.Encode()
 	for {
 		var serviceResp ServicesResponse
-		r := c.NewRequest("GET", requestUrl)
+		r := c.NewRequest("GET", requestURL)
 		resp, err := c.DoRequest(r)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error requesting services")
@@ -115,8 +115,8 @@ func (c *Client) ListServicesByQuery(query url.Values) ([]Service, error) {
 			service.Entity.c = c
 			services = append(services, service.Entity)
 		}
-		requestUrl = serviceResp.NextUrl
-		if requestUrl == "" {
+		requestURL = serviceResp.NextUrl
+		if requestURL == "" {
 			break
 		}
 	}

--- a/space_quotas.go
+++ b/space_quotas.go
@@ -116,13 +116,13 @@ func (c *Client) getSpaceQuotasResponse(requestUrl string) (SpaceQuotasResponse,
 }
 
 func (c *Client) AssignSpaceQuota(quotaGUID, spaceGUID string) error {
-	//Perform the PUT and check for errors
+	// Perform the PUT and check for errors
 	resp, err := c.DoRequest(c.NewRequest("PUT", fmt.Sprintf("/v2/space_quota_definitions/%s/spaces/%s", quotaGUID, spaceGUID)))
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusCreated { //201
+	if resp.StatusCode != http.StatusCreated { // 201
 		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
 	}
 	return nil

--- a/stacks.go
+++ b/stacks.go
@@ -32,9 +32,9 @@ type Stack struct {
 
 func (c *Client) ListStacksByQuery(query url.Values) ([]Stack, error) {
 	var stacks []Stack
-	requestUrl := "/v2/stacks?" + query.Encode()
+	requestURL := "/v2/stacks?" + query.Encode()
 	for {
-		stacksResp, err := c.getStacksResponse(requestUrl)
+		stacksResp, err := c.getStacksResponse(requestURL)
 		if err != nil {
 			return []Stack{}, err
 		}
@@ -45,8 +45,8 @@ func (c *Client) ListStacksByQuery(query url.Values) ([]Stack, error) {
 			stack.Entity.c = c
 			stacks = append(stacks, stack.Entity)
 		}
-		requestUrl = stacksResp.NextUrl
-		if requestUrl == "" {
+		requestURL = stacksResp.NextUrl
+		if requestURL == "" {
 			break
 		}
 	}
@@ -59,8 +59,8 @@ func (c *Client) ListStacks() ([]Stack, error) {
 
 func (c *Client) GetStackByGuid(stackGUID string) (Stack, error) {
 	var stacksRes StacksResource
-	requestUrl := fmt.Sprintf("/v2/stacks/%s", stackGUID)
-	r := c.NewRequest("GET", requestUrl)
+	requestURL := fmt.Sprintf("/v2/stacks/%s", stackGUID)
+	r := c.NewRequest("GET", requestURL)
 	resp, err := c.DoRequest(r)
 	if err != nil {
 		return Stack{}, errors.Wrap(err, "Error requesting stack info")
@@ -83,9 +83,9 @@ func (c *Client) GetStackByGuid(stackGUID string) (Stack, error) {
 	return stacksRes.Entity, nil
 }
 
-func (c *Client) getStacksResponse(requestUrl string) (StacksResponse, error) {
+func (c *Client) getStacksResponse(requestURL string) (StacksResponse, error) {
 	var stacksResp StacksResponse
-	r := c.NewRequest("GET", requestUrl)
+	r := c.NewRequest("GET", requestURL)
 	resp, err := c.DoRequest(r)
 	if err != nil {
 		return StacksResponse{}, errors.Wrap(err, "Error requesting stacks")

--- a/tasks.go
+++ b/tasks.go
@@ -201,7 +201,7 @@ func (c *Client) TerminateTask(guid string) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 202 {
+	if resp.StatusCode != http.StatusAccepted {
 		return errors.Wrapf(err, "Failed terminating task, response status code %d", resp.StatusCode)
 	}
 	return nil

--- a/user_provided_service_instances.go
+++ b/user_provided_service_instances.go
@@ -52,10 +52,10 @@ type UserProvidedServiceInstanceRequest struct {
 func (c *Client) ListUserProvidedServiceInstancesByQuery(query url.Values) ([]UserProvidedServiceInstance, error) {
 	var instances []UserProvidedServiceInstance
 
-	requestUrl := "/v2/user_provided_service_instances?" + query.Encode()
+	requestURL := "/v2/user_provided_service_instances?" + query.Encode()
 	for {
 		var sir UserProvidedServiceInstancesResponse
-		r := c.NewRequest("GET", requestUrl)
+		r := c.NewRequest("GET", requestURL)
 		resp, err := c.DoRequest(r)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error requesting user provided service instances")
@@ -78,8 +78,8 @@ func (c *Client) ListUserProvidedServiceInstancesByQuery(query url.Values) ([]Us
 			instances = append(instances, instance.Entity)
 		}
 
-		requestUrl = sir.NextUrl
-		if requestUrl == "" {
+		requestURL = sir.NextUrl
+		if requestURL == "" {
 			break
 		}
 	}

--- a/v3apps.go
+++ b/v3apps.go
@@ -226,8 +226,7 @@ func extractPathFromURL(requestURL string) (string, error) {
 		return "", err
 	}
 	result := url.Path
-	q := url.Query().Encode()
-	if q != "" {
+	if q := url.Query().Encode(); q != "" {
 		result = result + "?" + q
 	}
 	return result, nil


### PR DESCRIPTION
Applies many non-breaking, low hanging fruit linting suggestions of the golangci-lint tool.

- Remove superfluous comments on exported consts
- Correct spacing before comment start
- Replace magic-number status codes with net/http constants
- Close request response bodies
- Reduce variable scope to within if initializer
- Correct typo in log message
- Remove unused struct code
- Remove unused constant from payloads_test.go
- Panic on time.Parse() error instead of returning nil silently
- Prefer increment operator over +=1 syntax
- Prefer switch statements over if-elseif chains
- Correct capitalization of URL in non-exported usages
