### PR TITLE
Implement some missing v3 functions

### DIFF
--- a/payloads_test.go
+++ b/payloads_test.go
@@ -938,6 +938,270 @@ const spaceRolesPayload = `{
   ]
 }`
 
+const listV3SpaceRolesBySpaceGuidPayload = `{
+  "pagination": {
+    "total_results": 3,
+    "total_pages": 2,
+    "first": {
+      "href": "https://api.example.org/v3/roles?page=1&per_page=2&space_guids=spaceGUID1"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/roles?page=2&per_page=2&space_guids=spaceGUID1"
+    },
+    "next": {
+      "href": "https://api.example.org/v3/rolespage2?page=2&per_page=2&space_guids=spaceGUID1"
+    },
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "roleGUID1",
+      "created_at": "2019-10-10T17:19:12Z",
+      "updated_at": "2019-10-10T17:19:12Z",
+      "type": "space_developer",
+      "relationships": {
+        "user": {
+          "data": {
+            "guid": "userGUID1"
+          }
+        },
+        "space": {
+          "data": {
+            "guid": "spaceGUID1"
+          }
+        },
+        "organization": {
+          "data": null
+        }
+       },
+       "links": {
+          "self": {
+            "href": "https://api.example.org/v3/roles/roleGUID1"
+          },
+          "user": {
+            "href": "https://api.example.org/v3/users/userGUID1"
+          },
+          "space": {
+            "href": "https://api.example.org/v3/spaces/spaceGUID1"
+          }
+       }
+    },
+    {
+      "guid": "roleGUID2",
+      "created_at": "2047-11-10T17:19:12Z",
+      "updated_at": "2047-11-10T17:19:12Z",
+      "type": "space_auditor",
+      "relationships": {
+        "user": {
+          "data": {
+            "guid": "userGUID2"
+          }
+        },
+        "space": {
+          "data": {
+            "guid": "spaceGUID1"
+          }
+        },
+        "organization": {
+          "data": null
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/roles/roleGUID2"
+        },
+        "user": {
+          "href": "https://api.example.org/v3/users/userGUID2"
+        },
+        "space": {
+          "href": "https://api.example.org/v3/spaces/spaceGUID1"
+        }
+      }
+    }
+  ]
+}`
+
+const listV3SpaceRolesBySpaceGuidPayloadPage2 = `{
+  "pagination": {
+    "total_results": 3,
+    "total_pages": 2,
+    "first": {
+      "href": "https://api.example.org/v3/roles?page=1&per_page=2&space_guids=spaceGUID1"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/rolespage2?page=2&per_page=2&space_guids=spaceGUID1"
+    },
+    "next": null,
+    "previous": {
+      "href": "https://api.example.org/v3/roles?page=1&per_page=2&space_guids=spaceGUID1"
+    }
+  },
+  "resources": [
+    {
+      "guid": "roleGUID3",
+      "created_at": "2019-10-10T17:19:12Z",
+      "updated_at": "2019-10-10T17:19:12Z",
+      "type": "space_manager",
+      "relationships": {
+        "user": {
+          "data": {
+            "guid": "userGUID2"
+          }
+        },
+        "space": {
+          "data": {
+            "guid": "spaceGUID1"
+          }
+        },
+        "organization": {
+          "data": null
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/roles/roleGUID3"
+        },
+        "user": {
+          "href": "https://api.example.org/v3/users/userGUID2"
+        },
+        "space": {
+          "href": "https://api.example.org/v3/spaces/spaceGUID1"
+        }
+      }
+    }
+  ]
+}`
+
+const listV3SpaceRolesByUserGuidPayload = `{
+  "pagination": {
+    "total_results": 2,
+    "total_pages": 1,
+    "first": {
+      "href": "https://api.example.org/v3/roles?page=1&per_page=2&user_guids=userGUID1"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/roles?page=2&per_page=2&user_guids=userGUID1"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "roleGUID1",
+      "created_at": "2019-10-10T17:19:12Z",
+      "updated_at": "2019-10-10T17:19:12Z",
+      "type": "space_developer",
+      "relationships": {
+        "user": {
+          "data": {
+            "guid": "userGUID1"
+          }
+        },
+        "space": {
+          "data": {
+            "guid": "spaceGUID1"
+          }
+        },
+        "organization": {
+          "data": null
+        }
+       },
+       "links": {
+          "self": {
+            "href": "https://api.example.org/v3/roles/roleGUID1"
+          },
+          "user": {
+            "href": "https://api.example.org/v3/users/userGUID1"
+          },
+          "space": {
+            "href": "https://api.example.org/v3/spaces/spaceGUID1"
+          }
+       }
+    },
+    {
+      "guid": "roleGUID4",
+      "created_at": "2019-10-10T17:19:12Z",
+      "updated_at": "2019-10-10T17:19:12Z",
+      "type": "space_manager",
+      "relationships": {
+        "user": {
+          "data": {
+            "guid": "userGUID1"
+          }
+        },
+        "space": {
+          "data": {
+            "guid": "spaceGUID2"
+          }
+        },
+        "organization": {
+          "data": null
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/roles/roleGUID4"
+        },
+        "user": {
+          "href": "https://api.example.org/v3/users/userGUID1"
+        },
+        "space": {
+          "href": "https://api.example.org/v3/spaces/spaceGUID2"
+        }
+      }
+    }
+  ]
+}`
+
+const listV3spaceRolesBySpaceAndUserGuidPayload = `{
+  "pagination": {
+    "total_results": 1,
+    "total_pages": 1,
+    "first": {
+      "href": "https://api.example.org/v3/roles?page=1&per_page=1&space_guids=spaceGUID2&user_guids=userGUID1"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/roles?page=1&per_page=1&space_guids=spaceGUID2&user_guids=userGUID1"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "roleGUID4",
+      "created_at": "2019-10-10T17:19:12Z",
+      "updated_at": "2019-10-10T17:19:12Z",
+      "type": "space_manager",
+      "relationships": {
+        "user": {
+          "data": {
+            "guid": "userGUID1"
+          }
+        },
+        "space": {
+          "data": {
+            "guid": "spaceGUID2"
+          }
+        },
+        "organization": {
+          "data": null
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/roles/roleGUID4"
+        },
+        "user": {
+          "href": "https://api.example.org/v3/users/userGUID1"
+        },
+        "space": {
+          "href": "https://api.example.org/v3/spaces/spaceGUID2"
+        }
+      }
+    }
+  ]
+}`
+
 const spaceQuotaPayload = `{
    "metadata": {
       "guid": "9ffd7c5c-d83c-4786-b399-b7bd54883977",

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -3744,6 +3744,78 @@ const listV3SpacesPayloadPage2 = `{
   ]
 }`
 
+const listV3SpaceUsersPayload = `{
+  "pagination": {
+    "total_results": 2,
+    "total_pages": 2,
+    "first": {
+      "href": "https://api.example.org/v3/spaces/space-guid/users?page=1&per_page=1"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/spaces/space-guid/users?page=2&per_page=1"
+    },
+    "next": {
+      "href": "https://api.example.org/v3/spaces/space-guid/users?page=2&per_page=1"
+    },
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "10a93b89-3f89-4f05-7238-8a2b123c79l9",
+      "created_at": "2019-03-08T01:06:18Z",
+      "updated_at": "2019-03-08T01:06:18Z",
+      "username": "some-name-1",
+      "presentation_name": "some-name-1",
+      "origin": "uaa",
+      "metadata": {
+        "labels": {},
+        "annotations":{}
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/users/10a93b89-3f89-4f05-7238-8a2b123c79l9"
+        }
+      }
+    }
+  ]
+}`
+
+const listV3SpaceUsersPayloadPage2 = `{
+  "pagination": {
+    "total_results": 2,
+    "total_pages": 2,
+    "first": {
+      "href": "https://api.example.org/v3/spaces/space-guid/users?page=1&per_page=1"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/spaces/space-guid/users?page=2&per_page=1"
+    },
+    "next": null,
+    "previous": {
+      "href": "https://api.example.org/v3/spaces/space-guid/users?page=1&per_page=1"
+    }
+  },
+  "resources": [
+    {
+      "guid": "9da93b89-3f89-4f05-7238-8a2b123c79l9",
+      "created_at": "2019-03-08T01:06:19Z",
+      "updated_at": "2019-03-08T01:06:19Z",
+      "username": "some-name-2",
+      "presentation_name": "some-name-2",
+      "origin": "ldap",
+      "metadata": {
+        "labels": {},
+        "annotations":{}
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/users/9da93b89-3f89-4f05-7238-8a2b123c79l9"
+        }
+      }
+    }
+  ]
+}`
+
 const updateV3SpacePayload = `
 {
   "guid": "space-guid",

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -7109,3 +7109,52 @@ const listValidResources = `[
     "size": 1
   }
 ]`
+
+const listV3StacksPayload = `{
+  "pagination": {
+    "total_results": 2,
+    "total_pages": 1,
+    "first": {
+      "href": "https://api.example.org/v3/stacks?page=1&per_page=2"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/stacks?page=1&per_page=2"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "guid-1",
+      "created_at": "2018-11-09T22:43:28Z",
+      "updated_at": "2018-11-09T22:43:28Z",
+      "name": "my-stack-1",
+      "description": "This is my first stack!",
+      "metadata": {
+        "labels": {},
+        "annotations": {}
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/stacks/guid-1"
+        }
+      }
+    },
+    {
+      "guid": "guid-2",
+      "created_at": "2018-11-09T22:43:29Z",
+      "updated_at": "2018-11-09T22:43:29Z",
+      "name": "my-stack-2",
+      "description": "This is my second stack!",
+      "metadata": {
+        "labels": {},
+        "annotations": {}
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/stacks/guid-2"
+        }
+      }
+    }
+  ]
+}`

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -1647,6 +1647,45 @@ const listV3SecurityGroupsByGuidPayload = `{
   ]
 }`
 
+const createV3SecurityGroupPayload = `{
+  "guid": "guid-1",
+  "name": "my-sec-group",
+  "globally_enabled": {
+    "running": true,
+    "staging": false
+  },
+  "rules": [
+    {
+      "protocol": "tcp",
+      "destination": "10.10.10.0/24",
+      "ports": "443,80,8080"
+    },
+    {
+      "protocol": "icmp",
+      "destination": "10.10.11.0/24",
+      "type": 8,
+      "code": 0,
+      "description": "Allow ping requests to private services"
+    }
+  ],
+  "relationships": {
+    "staging_spaces": {
+      "data": []
+    },
+    "running_spaces": {
+      "data": [
+        { "guid": "space-guid-1" },
+        { "guid": "space-guid-2" }
+      ]
+    }
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/security_groups/guid-1"
+    }
+  }
+}`
+
 const listAppsPayload = `{
    "total_results": 28,
    "total_pages": 1,

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -1496,6 +1496,157 @@ const listStagingSecGroupsPayload = `{
   ]
 }`
 
+const listV3SecurityGroupsPayload = `{
+  "pagination": {
+    "total_results": 2,
+    "total_pages": 1,
+    "first": {
+      "href": "https://api.example.org/v3/security_groups?page=1&per_page=50"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/security_groups?page=1&per_page=50"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "guid-1",
+      "name": "my-group1",
+      "globally_enabled": {
+        "running": true,
+        "staging": false
+      },
+      "rules": [
+        {
+          "protocol": "tcp",
+          "destination": "1.2.3.4/10",
+          "ports": "443,80,8080"
+        },
+        {
+          "protocol": "icmp",
+          "destination": "1.2.3.4/12",
+          "type": 8,
+          "code": 0,
+          "description": "test-desc-1"
+        }
+      ],
+      "relationships": {
+        "staging_spaces": {
+          "data": [
+            { "guid": "space-guid-1" },
+            { "guid": "space-guid-2" }
+          ]
+        },
+        "running_spaces": {
+          "data": []
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/security_groups/guid-1"
+        }
+      }
+    },
+    {
+      "guid": "guid-2",
+      "name": "my-group2",
+      "globally_enabled": {
+        "running": false,
+        "staging": true
+      },
+      "rules": [
+        {
+          "protocol": "tcp",
+          "destination": "1.2.3.4/14",
+          "ports": "443,80,8080"
+        },
+        {
+          "protocol": "icmp",
+          "destination": "1.2.3.4/16",
+          "type": 5,
+          "code": 0,
+          "description": "test-desc-2"
+        }
+      ],
+      "relationships": {
+        "staging_spaces": {
+          "data": [
+            { "guid": "space-guid-3" },
+            { "guid": "space-guid-4" }
+          ]
+        },
+        "running_spaces": {
+          "data": [
+            { "guid": "space-guid-5" },
+            { "guid": "space-guid-6" }
+          ]
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/security_groups/guid-2"
+        }
+      }
+    }
+  ]
+}`
+
+const listV3SecurityGroupsByGuidPayload = `{
+  "pagination": {
+    "total_results": 1,
+    "total_pages": 1,
+    "first": {
+      "href": "https://api.example.org/v3/security_groups?page=1&per_page=50"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/security_groups?page=1&per_page=50"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "guid-1",
+      "name": "my-group1",
+      "globally_enabled": {
+        "running": true,
+        "staging": false
+      },
+      "rules": [
+        {
+          "protocol": "tcp",
+          "destination": "1.2.3.4/10",
+          "ports": "443,80,8080"
+        },
+        {
+          "protocol": "icmp",
+          "destination": "1.2.3.4/12",
+          "type": 8,
+          "code": 0,
+          "description": "test-desc-1"
+        }
+      ],
+      "relationships": {
+        "staging_spaces": {
+          "data": [
+            { "guid": "space-guid-1" },
+            { "guid": "space-guid-2" }
+          ]
+        },
+        "running_spaces": {
+          "data": []
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/security_groups/guid-1"
+        }
+      }
+    }
+  ]
+}`
+
 const listAppsPayload = `{
    "total_results": 28,
    "total_pages": 1,

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -938,7 +938,7 @@ const spaceRolesPayload = `{
   ]
 }`
 
-const listV3SpaceRolesBySpaceGuidPayload = `{
+const listV3SpaceRolesBySpaceGUIDPayload = `{
   "pagination": {
     "total_results": 3,
     "total_pages": 2,
@@ -1647,7 +1647,7 @@ const listV3SecurityGroupsByGuidPayload = `{
   ]
 }`
 
-const createV3SecurityGroupPayload = `{
+const createOrUpdateV3SecurityGroupPayload = `{
   "guid": "guid-1",
   "name": "my-sec-group",
   "globally_enabled": {

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -1647,7 +1647,7 @@ const listV3SecurityGroupsByGuidPayload = `{
   ]
 }`
 
-const createOrUpdateV3SecurityGroupPayload = `{
+const genericV3SecurityGroupPayload = `{
   "guid": "guid-1",
   "name": "my-sec-group",
   "globally_enabled": {

--- a/v3roles.go
+++ b/v3roles.go
@@ -18,7 +18,7 @@ type V3Role struct {
 	Links         map[string]Link                `json:"links,omitempty"`
 }
 
-type listV3SpaceRolesBySpaceGuidResponse struct {
+type listV3SpaceRolesResponse struct {
 	Pagination Pagination `json:"pagination,omitempty"`
 	Resources  []V3Role   `json:"resources,omitempty"`
 }
@@ -43,7 +43,7 @@ func (c *Client) ListV3RolesByQuery(query url.Values) ([]V3Role, error) {
 			return nil, fmt.Errorf("Error listing v3 space roles, response code: %d", resp.StatusCode)
 		}
 
-		var data listV3SpaceRolesBySpaceGuidResponse
+		var data listV3SpaceRolesResponse
 		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
 			return nil, errors.Wrap(err, "Error parsing JSON from list v3 space roles")
 		}

--- a/v3roles.go
+++ b/v3roles.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// V3Role implements role object. Roles control access to resources in organizations and spaces. Roles are assigned to users.
 type V3Role struct {
 	GUID          string                         `json:"guid,omitempty"`
 	CreatedAt     string                         `json:"created_at,omitempty"`
@@ -23,6 +24,7 @@ type listV3SpaceRolesResponse struct {
 	Resources  []V3Role   `json:"resources,omitempty"`
 }
 
+// ListV3RolesByQuery retrieves roles based on query
 func (c *Client) ListV3RolesByQuery(query url.Values) ([]V3Role, error) {
 	var roles []V3Role
 	requestURL, err := url.Parse("/v3/roles")

--- a/v3roles.go
+++ b/v3roles.go
@@ -1,0 +1,63 @@
+package cfclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+type V3Role struct {
+	GUID          string                         `json:"guid,omitempty"`
+	CreatedAt     string                         `json:"created_at,omitempty"`
+	UpdatedAt     string                         `json:"updated_at,omitempty"`
+	Type          string                         `json:"type,omitempty"`
+	Relationships map[string]V3ToOneRelationship `json:"relationships,omitempty"`
+	Links         map[string]Link                `json:"links,omitempty"`
+}
+
+type listV3SpaceRolesBySpaceGuidResponse struct {
+	Pagination Pagination `json:"pagination,omitempty"`
+	Resources  []V3Role   `json:"resources,omitempty"`
+}
+
+func (c *Client) ListV3RolesByQuery(query url.Values) ([]V3Role, error) {
+	var roles []V3Role
+	requestURL, err := url.Parse("/v3/roles")
+	if err != nil {
+		return nil, err
+	}
+	requestURL.RawQuery = query.Encode()
+
+	for {
+		r := c.NewRequest("GET", fmt.Sprintf("%s?%s", requestURL.Path, requestURL.RawQuery))
+		resp, err := c.DoRequest(r)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error requesting v3 space roles")
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("Error listing v3 space roles, response code: %d", resp.StatusCode)
+		}
+
+		var data listV3SpaceRolesBySpaceGuidResponse
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return nil, errors.Wrap(err, "Error parsing JSON from list v3 space roles")
+		}
+
+		roles = append(roles, data.Resources...)
+
+		requestURL, err = url.Parse(data.Pagination.Next.Href)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error parsing next page URL")
+		}
+		if requestURL.String() == "" {
+			break
+		}
+	}
+
+	return roles, nil
+}

--- a/v3roles_test.go
+++ b/v3roles_test.go
@@ -1,0 +1,100 @@
+package cfclient
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestListV3SpaceRolesByQuery(t *testing.T) {
+	Convey("List V3 Space Roles By Space GUID", t, func() {
+		mocks := []MockRoute{
+			{"GET", "/v3/roles", []string{listV3SpaceRolesBySpaceGuidPayload}, "", http.StatusOK, "space_guids=spaceGUID1", nil},
+			{"GET", "/v3/rolespage2", []string{listV3SpaceRolesBySpaceGuidPayloadPage2}, "", http.StatusOK, "page=2&per_page=2&space_guids=spaceGUID1", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		query := url.Values{}
+		query["space_guids"] = []string{"spaceGUID1"}
+
+		roles, err := client.ListV3RolesByQuery(query)
+		So(err, ShouldBeNil)
+		So(roles, ShouldHaveLength, 3)
+
+		So(roles[0].Type, ShouldEqual, "space_developer")
+		So(roles[1].Type, ShouldEqual, "space_auditor")
+		So(roles[2].Type, ShouldEqual, "space_manager")
+
+		So(roles[0].GUID, ShouldEqual, "roleGUID1")
+		So(roles[0].Relationships["user"].Data.GUID, ShouldEqual, "userGUID1")
+		So(roles[0].Relationships["space"].Data.GUID, ShouldEqual, "spaceGUID1")
+		So(roles[0].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/roles/roleGUID1")
+		So(roles[1].GUID, ShouldEqual, "roleGUID2")
+		So(roles[1].Relationships["user"].Data.GUID, ShouldEqual, "userGUID2")
+		So(roles[1].Relationships["space"].Data.GUID, ShouldEqual, "spaceGUID1")
+		So(roles[1].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/roles/roleGUID2")
+		So(roles[2].GUID, ShouldEqual, "roleGUID3")
+		So(roles[2].Relationships["user"].Data.GUID, ShouldEqual, "userGUID2")
+		So(roles[2].Relationships["space"].Data.GUID, ShouldEqual, "spaceGUID1")
+		So(roles[2].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/roles/roleGUID3")
+	})
+
+	Convey("List V3 Space Roles By User GUID", t, func() {
+		setup(MockRoute{"GET", "/v3/roles", []string{listV3SpaceRolesByUserGuidPayload}, "", http.StatusOK, "user_guids=userGUID1", nil}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		query := url.Values{}
+		query["user_guids"] = []string{"userGUID1"}
+
+		roles, err := client.ListV3RolesByQuery(query)
+		So(err, ShouldBeNil)
+		So(roles, ShouldHaveLength, 2)
+
+		So(roles[0].Type, ShouldEqual, "space_developer")
+		So(roles[1].Type, ShouldEqual, "space_manager")
+
+		So(roles[0].GUID, ShouldEqual, "roleGUID1")
+		So(roles[0].Relationships["user"].Data.GUID, ShouldEqual, "userGUID1")
+		So(roles[0].Relationships["space"].Data.GUID, ShouldEqual, "spaceGUID1")
+		So(roles[0].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/roles/roleGUID1")
+		So(roles[1].GUID, ShouldEqual, "roleGUID4")
+		So(roles[1].Relationships["user"].Data.GUID, ShouldEqual, "userGUID1")
+		So(roles[1].Relationships["space"].Data.GUID, ShouldEqual, "spaceGUID2")
+		So(roles[1].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/roles/roleGUID4")
+	})
+
+	Convey("List V3 Space Users By Space Guid and User GUID", t, func() {
+		setup(MockRoute{"GET", "/v3/roles", []string{listV3spaceRolesBySpaceAndUserGuidPayload}, "", http.StatusOK, "space_guids=spaceGUID2&user_guids=userGUID1", nil}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		query := url.Values{}
+		query["space_guids"] = []string{"spaceGUID2"}
+		query["user_guids"] = []string{"userGUID1"}
+
+		roles, err := client.ListV3RolesByQuery(query)
+		So(err, ShouldBeNil)
+		So(roles, ShouldHaveLength, 1)
+
+		So(roles[0].Type, ShouldEqual, "space_manager")
+
+		So(roles[0].GUID, ShouldEqual, "roleGUID4")
+		So(roles[0].Relationships["user"].Data.GUID, ShouldEqual, "userGUID1")
+		So(roles[0].Relationships["space"].Data.GUID, ShouldEqual, "spaceGUID2")
+		So(roles[0].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/roles/roleGUID4")
+	})
+}

--- a/v3roles_test.go
+++ b/v3roles_test.go
@@ -11,7 +11,7 @@ import (
 func TestListV3SpaceRolesByQuery(t *testing.T) {
 	Convey("List V3 Space Roles By Space GUID", t, func() {
 		mocks := []MockRoute{
-			{"GET", "/v3/roles", []string{listV3SpaceRolesBySpaceGuidPayload}, "", http.StatusOK, "space_guids=spaceGUID1", nil},
+			{"GET", "/v3/roles", []string{listV3SpaceRolesBySpaceGUIDPayload}, "", http.StatusOK, "space_guids=spaceGUID1", nil},
 			{"GET", "/v3/rolespage2", []string{listV3SpaceRolesBySpaceGuidPayloadPage2}, "", http.StatusOK, "page=2&per_page=2&space_guids=spaceGUID1", nil},
 		}
 		setupMultiple(mocks, t)

--- a/v3security_groups.go
+++ b/v3security_groups.go
@@ -1,0 +1,80 @@
+package cfclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+type V3SecurityGroup struct {
+	Name            string                           `json:"name,omitempty"`
+	GUID            string                           `json:"guid,omitempty"`
+	CreatedAt       string                           `json:"created_at,omitempty"`
+	UpdatedAt       string                           `json:"updated_at,omitempty"`
+	GloballyEnabled V3GloballyEnabled                `json:"globally_enabled,omitempty"`
+	Rules           []V3Rule                         `json:"rules,omitempty"`
+	Relationships   map[string]V3ToManyRelationships `json:"relationships,omitempty"`
+	Links           map[string]Link                  `json:"links,omitempty"`
+}
+
+type V3GloballyEnabled struct {
+	Running bool `json:"running"`
+	Staging bool `json:"staging"`
+}
+
+type V3Rule struct {
+	Protocol    string `json:"protocol,omitempty"`
+	Destination string `json:"destination,omitempty"`
+	Ports       string `json:"ports,omitempty"`
+	Type        int    `json:"type,omitempty"`
+	Code        int    `json:"code,omitempty"`
+	Description string `json:"description,omitempty"`
+	Log         bool   `json:"log,omitempty"`
+}
+
+type listV3SecurityGroupResponse struct {
+	Pagination Pagination        `json:"pagination,omitempty"`
+	Resources  []V3SecurityGroup `json:"resources,omitempty"`
+}
+
+func (c *Client) ListV3SecGroupsByQuery(query url.Values) ([]V3SecurityGroup, error) {
+	var security_groups []V3SecurityGroup
+	requestURL, err := url.Parse("/v3/security_groups")
+	if err != nil {
+		return nil, err
+	}
+	requestURL.RawQuery = query.Encode()
+
+	for {
+		r := c.NewRequest("GET", fmt.Sprintf("%s?%s", requestURL.Path, requestURL.RawQuery))
+		resp, err := c.DoRequest(r)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error requesting v3 security groups")
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("Error listing v3 security groups, response code: %d", resp.StatusCode)
+		}
+
+		var data listV3SecurityGroupResponse
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return nil, errors.Wrap(err, "Error parsing JSON from list v3 security groups")
+		}
+
+		security_groups = append(security_groups, data.Resources...)
+
+		requestURL, err = url.Parse(data.Pagination.Next.Href)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error parsing next page URL")
+		}
+		if requestURL.String() == "" {
+			break
+		}
+	}
+
+	return security_groups, nil
+}

--- a/v3security_groups.go
+++ b/v3security_groups.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// V3SecurityGroup implements the security group object. Security groups are collections of egress traffic rules that can be applied to the staging or running state of applications.
 type V3SecurityGroup struct {
 	Name            string                           `json:"name,omitempty"`
 	GUID            string                           `json:"guid,omitempty"`
@@ -21,11 +22,13 @@ type V3SecurityGroup struct {
 	Links           map[string]Link                  `json:"links,omitempty"`
 }
 
+// V3GloballyEnabled object controls if the group is applied globally to the lifecycle of all applications
 type V3GloballyEnabled struct {
 	Running bool `json:"running,omitempty"`
 	Staging bool `json:"staging,omitempty"`
 }
 
+// V3Rule is an object that provide a rule that will be applied by a security group
 type V3Rule struct {
 	Protocol    string `json:"protocol,omitempty"`
 	Destination string `json:"destination,omitempty"`
@@ -41,6 +44,7 @@ type listV3SecurityGroupResponse struct {
 	Resources  []V3SecurityGroup `json:"resources,omitempty"`
 }
 
+// ListV3SecurityGroupsByQuery retrieves security groups based on query
 func (c *Client) ListV3SecurityGroupsByQuery(query url.Values) ([]V3SecurityGroup, error) {
 	var securityGroups []V3SecurityGroup
 	requestURL, err := url.Parse("/v3/security_groups")
@@ -80,6 +84,7 @@ func (c *Client) ListV3SecurityGroupsByQuery(query url.Values) ([]V3SecurityGrou
 	return securityGroups, nil
 }
 
+// CreateV3SecurityGroupRequest implements an object that is passed to CreateV3SecurityGroup method
 type CreateV3SecurityGroupRequest struct {
 	Name            string                           `json:"name"`
 	GloballyEnabled *V3GloballyEnabled               `json:"globally_enabled,omitempty"`
@@ -87,6 +92,7 @@ type CreateV3SecurityGroupRequest struct {
 	Relationships   map[string]V3ToManyRelationships `json:"relationships,omitempty"`
 }
 
+// CreateV3SecurityGroup creates security group from CreateV3SecurityGroupRequest
 func (c *Client) CreateV3SecurityGroup(r CreateV3SecurityGroupRequest) (*V3SecurityGroup, error) {
 	req := c.NewRequest("POST", "/v3/security_groups")
 
@@ -115,6 +121,7 @@ func (c *Client) CreateV3SecurityGroup(r CreateV3SecurityGroupRequest) (*V3Secur
 	return &securitygroup, nil
 }
 
+// DeleteV3SecurityGroup deletes security group by GUID
 func (c *Client) DeleteV3SecurityGroup(GUID string) error {
 	req := c.NewRequest("DELETE", "/v3/security_groups/"+GUID)
 
@@ -130,12 +137,14 @@ func (c *Client) DeleteV3SecurityGroup(GUID string) error {
 	return nil
 }
 
+// UpdateV3SecurityGroupRequest implements an object that is passed to UpdateV3SecurityGroup method
 type UpdateV3SecurityGroupRequest struct {
 	Name            string             `json:"name,omitempty"`
 	GloballyEnabled *V3GloballyEnabled `json:"globally_enabled,omitempty"`
 	Rules           []*V3Rule          `json:"rules,omitempty"`
 }
 
+// UpdateV3SecurityGroup updates security group by GUID and from UpdateV3SecurityGroupRequest
 func (c *Client) UpdateV3SecurityGroup(GUID string, r UpdateV3SecurityGroupRequest) (*V3SecurityGroup, error) {
 	req := c.NewRequest("PATCH", "/v3/security_groups/"+GUID)
 	buf := bytes.NewBuffer(nil)

--- a/v3security_groups.go
+++ b/v3security_groups.go
@@ -171,3 +171,25 @@ func (c *Client) UpdateV3SecurityGroup(GUID string, r UpdateV3SecurityGroupReque
 
 	return &securityGroup, nil
 }
+
+// GetV3SecurityGroupByGUID retrieves security group base on provided GUID
+func (c *Client) GetV3SecurityGroupByGUID(GUID string) (*V3SecurityGroup, error) {
+	req := c.NewRequest("GET", "/v3/security_groups/"+GUID)
+
+	resp, err := c.DoRequest(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error while getting v3 security group")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Error getting v3 security group with GUID [%s], response code: %d", GUID, resp.StatusCode)
+	}
+
+	var securityGroup V3SecurityGroup
+	if err := json.NewDecoder(resp.Body).Decode(&securityGroup); err != nil {
+		return nil, errors.Wrap(err, "Error reading v3 security group JSON")
+	}
+
+	return &securityGroup, nil
+}

--- a/v3security_groups_test.go
+++ b/v3security_groups_test.go
@@ -1,6 +1,8 @@
 package cfclient
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/url"
 	"testing"
@@ -33,8 +35,8 @@ func TestListV3SecurityGroupsByQuery(t *testing.T) {
 		So(securityGroups[0].Rules[0].Protocol, ShouldEqual, "tcp")
 		So(securityGroups[0].Rules[0].Destination, ShouldEqual, "1.2.3.4/10")
 		So(securityGroups[0].Rules[0].Ports, ShouldEqual, "443,80,8080")
-		So(securityGroups[0].Rules[1].Type, ShouldEqual, 8)
-		So(securityGroups[0].Rules[1].Code, ShouldEqual, 0)
+		So(*securityGroups[0].Rules[1].Type, ShouldEqual, 8)
+		So(*securityGroups[0].Rules[1].Code, ShouldEqual, 0)
 		So(securityGroups[0].Rules[1].Description, ShouldEqual, "test-desc-1")
 		So(securityGroups[0].Relationships["staging_spaces"].Data[0].GUID, ShouldEqual, "space-guid-1")
 		So(securityGroups[0].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/security_groups/guid-1")
@@ -42,8 +44,8 @@ func TestListV3SecurityGroupsByQuery(t *testing.T) {
 		So(securityGroups[1].Rules[1].Protocol, ShouldEqual, "icmp")
 		So(securityGroups[1].Rules[1].Destination, ShouldEqual, "1.2.3.4/16")
 		So(securityGroups[1].Rules[0].Ports, ShouldEqual, "443,80,8080")
-		So(securityGroups[1].Rules[1].Type, ShouldEqual, 5)
-		So(securityGroups[1].Rules[1].Code, ShouldEqual, 0)
+		So(*securityGroups[1].Rules[1].Type, ShouldEqual, 5)
+		So(*securityGroups[1].Rules[1].Code, ShouldEqual, 0)
 		So(securityGroups[1].Rules[1].Description, ShouldEqual, "test-desc-2")
 		So(securityGroups[1].Relationships["running_spaces"].Data[0].GUID, ShouldEqual, "space-guid-5")
 		So(securityGroups[1].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/security_groups/guid-2")
@@ -74,10 +76,134 @@ func TestListV3SecurityGroupsByQuery(t *testing.T) {
 		So(securityGroups[0].Rules[0].Protocol, ShouldEqual, "tcp")
 		So(securityGroups[0].Rules[0].Destination, ShouldEqual, "1.2.3.4/10")
 		So(securityGroups[0].Rules[0].Ports, ShouldEqual, "443,80,8080")
-		So(securityGroups[0].Rules[1].Type, ShouldEqual, 8)
-		So(securityGroups[0].Rules[1].Code, ShouldEqual, 0)
+		So(*securityGroups[0].Rules[1].Type, ShouldEqual, 8)
+		So(*securityGroups[0].Rules[1].Code, ShouldEqual, 0)
 		So(securityGroups[0].Rules[1].Description, ShouldEqual, "test-desc-1")
 		So(securityGroups[0].Relationships["staging_spaces"].Data[0].GUID, ShouldEqual, "space-guid-1")
 		So(securityGroups[0].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/security_groups/guid-1")
+	})
+}
+
+func TestCreateV3SecurityGroup(t *testing.T) {
+	Convey("Create V3 Security Group With Minimal Parameters", t, func() {
+		expectedRequestBody := `{"name":"my-sec-group"}`
+		expectedResponseBody := `{"guid":"guid-1", "name":"my-sec-group", "globally_enabled": {"running": false,"staging": false}, "rules": []}`
+		setup(MockRoute{"POST", "/v3/security_groups", []string{expectedResponseBody}, "", http.StatusCreated, "", &expectedRequestBody}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		securityGroups, err := client.CreateV3SecGroup(CreateV3SecGroupRequest{
+			Name: "my-sec-group",
+		})
+		So(err, ShouldBeNil)
+		So(securityGroups, ShouldNotBeNil)
+		So(securityGroups.GUID, ShouldEqual, "guid-1")
+		So(securityGroups.Name, ShouldEqual, "my-sec-group")
+		So(securityGroups.GloballyEnabled.Running, ShouldEqual, false)
+		So(securityGroups.GloballyEnabled.Staging, ShouldEqual, false)
+		So(len(securityGroups.Rules), ShouldEqual, 0)
+	})
+
+	Convey("Create V3 Security Group With Optional Parameters", t, func() {
+		requestBody := `{
+			"name": "my-sec-group",
+			"globally_enabled": {
+			  "running": true
+			},
+			"rules": [
+			  {
+				"protocol": "tcp",
+				"destination": "10.10.10.0/24",
+				"ports": "443,80,8080"
+			  },
+			  {
+				"protocol": "icmp",
+				"destination": "10.10.11.0/24",
+				"type": 8,
+				"code": 0,
+				"description": "Allow ping requests to private services"
+			  }
+			],
+			"relationships": {
+			  "running_spaces": {
+				"data": [
+				  {
+					"guid": "space-guid-1"
+				  },
+				  {
+					"guid": "space-guid-2"
+				  }
+				]
+			  }
+			}
+		  }`
+		buffer := new(bytes.Buffer)
+		err := json.Compact(buffer, []byte(requestBody))
+		buffer.Bytes()
+		expectedRequestBody := string(buffer.Bytes())
+		setup(MockRoute{"POST", "/v3/security_groups", []string{createV3SecurityGroupPayload}, "", http.StatusCreated, "", &expectedRequestBody}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+		icmpType := 8
+		icmpCode := 0
+		createV3SecGroupRequest := CreateV3SecGroupRequest{
+			Name: "my-sec-group",
+			GloballyEnabled: &V3GloballyEnabled{
+				Running: true,
+				Staging: false,
+			},
+			Rules: []*V3Rule{
+				{
+					Protocol:    "tcp",
+					Destination: "10.10.10.0/24",
+					Ports:       "443,80,8080",
+				},
+				{
+					Protocol:    "icmp",
+					Destination: "10.10.11.0/24",
+					Type:        &icmpType,
+					Code:        &icmpCode,
+					Description: "Allow ping requests to private services",
+				},
+			},
+			Relationships: map[string]V3ToManyRelationships{
+				"running_spaces": {
+					Data: []V3Relationship{
+						{
+							GUID: "space-guid-1",
+						},
+						{
+							GUID: "space-guid-2",
+						},
+					},
+				},
+			},
+		}
+
+		securityGroups, err := client.CreateV3SecGroup(createV3SecGroupRequest)
+		So(err, ShouldBeNil)
+		So(securityGroups, ShouldNotBeNil)
+		So(securityGroups.GUID, ShouldEqual, "guid-1")
+		So(securityGroups.Name, ShouldEqual, "my-sec-group")
+		So(securityGroups.GloballyEnabled.Running, ShouldEqual, true)
+		So(securityGroups.GloballyEnabled.Staging, ShouldEqual, false)
+		So(securityGroups.Rules[0].Protocol, ShouldEqual, "tcp")
+		So(securityGroups.Rules[0].Destination, ShouldEqual, "10.10.10.0/24")
+		So(securityGroups.Rules[0].Ports, ShouldEqual, "443,80,8080")
+		So(securityGroups.Rules[1].Protocol, ShouldEqual, "icmp")
+		So(securityGroups.Rules[1].Destination, ShouldEqual, "10.10.11.0/24")
+		So(*securityGroups.Rules[1].Type, ShouldEqual, 8)
+		So(*securityGroups.Rules[1].Code, ShouldEqual, 0)
+		So(securityGroups.Rules[1].Description, ShouldEqual, "Allow ping requests to private services")
+		So(len(securityGroups.Relationships["staging_spaces"].Data), ShouldEqual, 0)
+		So(securityGroups.Relationships["running_spaces"].Data[0].GUID, ShouldEqual, "space-guid-1")
+		So(securityGroups.Relationships["running_spaces"].Data[1].GUID, ShouldEqual, "space-guid-2")
+		So(securityGroups.Links["self"].Href, ShouldEqual, "https://api.example.org/v3/security_groups/guid-1")
 	})
 }

--- a/v3security_groups_test.go
+++ b/v3security_groups_test.go
@@ -1,0 +1,83 @@
+package cfclient
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestListV3SecurityGroupsByQuery(t *testing.T) {
+	Convey("List All V3 Security Groups", t, func() {
+		mocks := []MockRoute{
+			{"GET", "/v3/security_groups", []string{listV3SecurityGroupsPayload}, "", http.StatusOK, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		securityGroups, err := client.ListV3SecGroupsByQuery(nil)
+		So(err, ShouldBeNil)
+		So(securityGroups, ShouldHaveLength, 2)
+
+		So(securityGroups[0].Name, ShouldEqual, "my-group1")
+		So(securityGroups[0].GUID, ShouldEqual, "guid-1")
+		So(securityGroups[1].Name, ShouldEqual, "my-group2")
+		So(securityGroups[1].GUID, ShouldEqual, "guid-2")
+
+		So(securityGroups[0].GloballyEnabled.Running, ShouldEqual, true)
+		So(securityGroups[0].Rules[0].Protocol, ShouldEqual, "tcp")
+		So(securityGroups[0].Rules[0].Destination, ShouldEqual, "1.2.3.4/10")
+		So(securityGroups[0].Rules[0].Ports, ShouldEqual, "443,80,8080")
+		So(securityGroups[0].Rules[1].Type, ShouldEqual, 8)
+		So(securityGroups[0].Rules[1].Code, ShouldEqual, 0)
+		So(securityGroups[0].Rules[1].Description, ShouldEqual, "test-desc-1")
+		So(securityGroups[0].Relationships["staging_spaces"].Data[0].GUID, ShouldEqual, "space-guid-1")
+		So(securityGroups[0].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/security_groups/guid-1")
+		So(securityGroups[1].GloballyEnabled.Staging, ShouldEqual, true)
+		So(securityGroups[1].Rules[1].Protocol, ShouldEqual, "icmp")
+		So(securityGroups[1].Rules[1].Destination, ShouldEqual, "1.2.3.4/16")
+		So(securityGroups[1].Rules[0].Ports, ShouldEqual, "443,80,8080")
+		So(securityGroups[1].Rules[1].Type, ShouldEqual, 5)
+		So(securityGroups[1].Rules[1].Code, ShouldEqual, 0)
+		So(securityGroups[1].Rules[1].Description, ShouldEqual, "test-desc-2")
+		So(securityGroups[1].Relationships["running_spaces"].Data[0].GUID, ShouldEqual, "space-guid-5")
+		So(securityGroups[1].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/security_groups/guid-2")
+	})
+
+	Convey("List V3 Security Groups By GUID", t, func() {
+		mocks := []MockRoute{
+			{"GET", "/v3/security_groups", []string{listV3SecurityGroupsByGuidPayload}, "", http.StatusOK, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		query := url.Values{}
+		query["guids"] = []string{"guid-1"}
+
+		securityGroups, err := client.ListV3SecGroupsByQuery(query)
+		So(err, ShouldBeNil)
+		So(securityGroups, ShouldHaveLength, 1)
+
+		So(securityGroups[0].Name, ShouldEqual, "my-group1")
+		So(securityGroups[0].GUID, ShouldEqual, "guid-1")
+
+		So(securityGroups[0].GloballyEnabled.Running, ShouldEqual, true)
+		So(securityGroups[0].Rules[0].Protocol, ShouldEqual, "tcp")
+		So(securityGroups[0].Rules[0].Destination, ShouldEqual, "1.2.3.4/10")
+		So(securityGroups[0].Rules[0].Ports, ShouldEqual, "443,80,8080")
+		So(securityGroups[0].Rules[1].Type, ShouldEqual, 8)
+		So(securityGroups[0].Rules[1].Code, ShouldEqual, 0)
+		So(securityGroups[0].Rules[1].Description, ShouldEqual, "test-desc-1")
+		So(securityGroups[0].Relationships["staging_spaces"].Data[0].GUID, ShouldEqual, "space-guid-1")
+		So(securityGroups[0].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/security_groups/guid-1")
+	})
+}

--- a/v3security_groups_test.go
+++ b/v3security_groups_test.go
@@ -22,7 +22,7 @@ func TestListV3SecurityGroupsByQuery(t *testing.T) {
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 
-		securityGroups, err := client.ListV3SecGroupsByQuery(nil)
+		securityGroups, err := client.ListV3SecurityGroupsByQuery(nil)
 		So(err, ShouldBeNil)
 		So(securityGroups, ShouldHaveLength, 2)
 
@@ -65,7 +65,7 @@ func TestListV3SecurityGroupsByQuery(t *testing.T) {
 		query := url.Values{}
 		query["guids"] = []string{"guid-1"}
 
-		securityGroups, err := client.ListV3SecGroupsByQuery(query)
+		securityGroups, err := client.ListV3SecurityGroupsByQuery(query)
 		So(err, ShouldBeNil)
 		So(securityGroups, ShouldHaveLength, 1)
 
@@ -95,7 +95,7 @@ func TestCreateV3SecurityGroup(t *testing.T) {
 		client, err := NewClient(c)
 		So(err, ShouldBeNil)
 
-		securityGroups, err := client.CreateV3SecGroup(CreateV3SecGroupRequest{
+		securityGroups, err := client.CreateV3SecurityGroup(CreateV3SecurityGroupRequest{
 			Name: "my-sec-group",
 		})
 		So(err, ShouldBeNil)
@@ -144,7 +144,7 @@ func TestCreateV3SecurityGroup(t *testing.T) {
 		err := json.Compact(buffer, []byte(requestBody))
 		buffer.Bytes()
 		expectedRequestBody := string(buffer.Bytes())
-		setup(MockRoute{"POST", "/v3/security_groups", []string{createV3SecurityGroupPayload}, "", http.StatusCreated, "", &expectedRequestBody}, t)
+		setup(MockRoute{"POST", "/v3/security_groups", []string{createOrUpdateV3SecurityGroupPayload}, "", http.StatusCreated, "", &expectedRequestBody}, t)
 		defer teardown()
 
 		c := &Config{ApiAddress: server.URL, Token: "foobar"}
@@ -152,7 +152,7 @@ func TestCreateV3SecurityGroup(t *testing.T) {
 		So(err, ShouldBeNil)
 		icmpType := 8
 		icmpCode := 0
-		createV3SecGroupRequest := CreateV3SecGroupRequest{
+		createV3SecGroupRequest := CreateV3SecurityGroupRequest{
 			Name: "my-sec-group",
 			GloballyEnabled: &V3GloballyEnabled{
 				Running: true,
@@ -186,7 +186,184 @@ func TestCreateV3SecurityGroup(t *testing.T) {
 			},
 		}
 
-		securityGroups, err := client.CreateV3SecGroup(createV3SecGroupRequest)
+		securityGroups, err := client.CreateV3SecurityGroup(createV3SecGroupRequest)
+		So(err, ShouldBeNil)
+		So(securityGroups, ShouldNotBeNil)
+		So(securityGroups.GUID, ShouldEqual, "guid-1")
+		So(securityGroups.Name, ShouldEqual, "my-sec-group")
+		So(securityGroups.GloballyEnabled.Running, ShouldEqual, true)
+		So(securityGroups.GloballyEnabled.Staging, ShouldEqual, false)
+		So(securityGroups.Rules[0].Protocol, ShouldEqual, "tcp")
+		So(securityGroups.Rules[0].Destination, ShouldEqual, "10.10.10.0/24")
+		So(securityGroups.Rules[0].Ports, ShouldEqual, "443,80,8080")
+		So(securityGroups.Rules[1].Protocol, ShouldEqual, "icmp")
+		So(securityGroups.Rules[1].Destination, ShouldEqual, "10.10.11.0/24")
+		So(*securityGroups.Rules[1].Type, ShouldEqual, 8)
+		So(*securityGroups.Rules[1].Code, ShouldEqual, 0)
+		So(securityGroups.Rules[1].Description, ShouldEqual, "Allow ping requests to private services")
+		So(len(securityGroups.Relationships["staging_spaces"].Data), ShouldEqual, 0)
+		So(securityGroups.Relationships["running_spaces"].Data[0].GUID, ShouldEqual, "space-guid-1")
+		So(securityGroups.Relationships["running_spaces"].Data[1].GUID, ShouldEqual, "space-guid-2")
+		So(securityGroups.Links["self"].Href, ShouldEqual, "https://api.example.org/v3/security_groups/guid-1")
+	})
+	Convey("Create V3 Security Group with empty icmp type and code and no name", t, func() {
+		expectedRequestBody := `{"name":"","rules":[{"protocol":"icmp","destination":"10.10.11.0/24"}]}`
+		expectedResponseBody := `{
+			"errors": [
+			  {
+				"code": 10008,
+				"detail": "Rules[0]: code is required for protocols of type ICMP, Rules[0]: code must be an integer between -1 and 255 (inclusive), Rules[0]: type is required for protocols of type ICMP, Rules[0]: type must be an integer between -1 and 255 (inclusive), Name can't be blank, Name must be a string",
+				"title": "CF-UnprocessableEntity"
+			  }
+			]
+		  }`
+		setup(MockRoute{"POST", "/v3/security_groups", []string{expectedResponseBody}, "", http.StatusUnprocessableEntity, "", &expectedRequestBody}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		_, err = client.CreateV3SecurityGroup(CreateV3SecurityGroupRequest{
+			Rules: []*V3Rule{
+				{
+					Protocol:    "icmp",
+					Destination: "10.10.11.0/24",
+				},
+			},
+		})
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "code is required for protocols of type ICMP")
+		So(err.Error(), ShouldContainSubstring, "type is required for protocols of type ICMP")
+		So(err.Error(), ShouldContainSubstring, "Name can't be blank, Name must be a string")
+
+	})
+}
+
+func TestDeleteV3SecurityGroup(t *testing.T) {
+	Convey("Delete V3 Security Group", t, func() {
+		setup(MockRoute{"DELETE", "/v3/security_groups/security-group-guid", []string{""}, "", http.StatusAccepted, "", nil}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		err = client.DeleteV3SecurityGroup("security-group-guid")
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestUpdateV3SecurityGroup(t *testing.T) {
+	Convey("Update V3 Security Group with empty type and code", t, func() {
+		expectedRequestBody := `{"rules":[{"protocol":"icmp","destination":"10.10.11.0/24"}]}`
+		expectedResponseBody := `{
+			"errors": [
+			  {
+				"code": 10008,
+				"detail": "Rules[0]: code is required for protocols of type ICMP, Rules[0]: code must be an integer between -1 and 255 (inclusive), Rules[0]: type is required for protocols of type ICMP, Rules[0]: type must be an integer between -1 and 255 (inclusive)",
+				"title": "CF-UnprocessableEntity"
+			  }
+			]
+		  }`
+		setup(MockRoute{"PATCH", "/v3/security_groups/guid-1", []string{expectedResponseBody}, "", http.StatusUnprocessableEntity, "", &expectedRequestBody}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		_, err = client.UpdateV3SecurityGroup("guid-1", UpdateV3SecurityGroupRequest{
+			Rules: []*V3Rule{
+				{
+					Protocol:    "icmp",
+					Destination: "10.10.11.0/24",
+				},
+			},
+		})
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "code is required for protocols of type ICMP")
+		So(err.Error(), ShouldContainSubstring, "type is required for protocols of type ICMP")
+	})
+
+	Convey("Update name of V3 Security Group", t, func() {
+		expectedRequestBody := `{"name":"my-sec-group"}`
+		expectedResponseBody := `{"guid":"guid-1", "name":"my-sec-group", "globally_enabled": {"running": false,"staging": false}, "rules": []}`
+		setup(MockRoute{"PATCH", "/v3/security_groups/guid-1", []string{expectedResponseBody}, "", http.StatusOK, "", &expectedRequestBody}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		securityGroups, err := client.UpdateV3SecurityGroup("guid-1", UpdateV3SecurityGroupRequest{
+			Name: "my-sec-group",
+		})
+		So(err, ShouldBeNil)
+		So(securityGroups, ShouldNotBeNil)
+		So(securityGroups.GUID, ShouldEqual, "guid-1")
+		So(securityGroups.Name, ShouldEqual, "my-sec-group")
+		So(securityGroups.GloballyEnabled.Running, ShouldEqual, false)
+		So(securityGroups.GloballyEnabled.Staging, ShouldEqual, false)
+		So(len(securityGroups.Rules), ShouldEqual, 0)
+	})
+
+	Convey("Update V3 Security Group With Optional Parameters", t, func() {
+		requestBody := `{
+			"name": "my-sec-group",
+			"globally_enabled": {
+			  "running": true
+			},
+			"rules": [
+			  {
+				"protocol": "tcp",
+				"destination": "10.10.10.0/24",
+				"ports": "443,80,8080"
+			  },
+			  {
+				"protocol": "icmp",
+				"destination": "10.10.11.0/24",
+				"type": 8,
+				"code": 0,
+				"description": "Allow ping requests to private services"
+			  }
+			]
+		  }`
+		buffer := new(bytes.Buffer)
+		err := json.Compact(buffer, []byte(requestBody))
+		buffer.Bytes()
+		expectedRequestBody := string(buffer.Bytes())
+		setup(MockRoute{"PATCH", "/v3/security_groups/guid-1", []string{createOrUpdateV3SecurityGroupPayload}, "", http.StatusOK, "", &expectedRequestBody}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+		icmpType := 8
+		icmpCode := 0
+		updateV3SecGroupRequest := UpdateV3SecurityGroupRequest{
+			Name: "my-sec-group",
+			GloballyEnabled: &V3GloballyEnabled{
+				Running: true,
+				Staging: false,
+			},
+			Rules: []*V3Rule{
+				{
+					Protocol:    "tcp",
+					Destination: "10.10.10.0/24",
+					Ports:       "443,80,8080",
+				},
+				{
+					Protocol:    "icmp",
+					Destination: "10.10.11.0/24",
+					Type:        &icmpType,
+					Code:        &icmpCode,
+					Description: "Allow ping requests to private services",
+				},
+			},
+		}
+
+		securityGroups, err := client.UpdateV3SecurityGroup("guid-1", updateV3SecGroupRequest)
 		So(err, ShouldBeNil)
 		So(securityGroups, ShouldNotBeNil)
 		So(securityGroups.GUID, ShouldEqual, "guid-1")

--- a/v3security_groups_test.go
+++ b/v3security_groups_test.go
@@ -142,8 +142,8 @@ func TestCreateV3SecurityGroup(t *testing.T) {
 		  }`
 		buffer := new(bytes.Buffer)
 		err := json.Compact(buffer, []byte(requestBody))
-		buffer.Bytes()
-		expectedRequestBody := string(buffer.Bytes())
+		So(err, ShouldBeNil)
+		expectedRequestBody := buffer.String()
 		setup(MockRoute{"POST", "/v3/security_groups", []string{genericV3SecurityGroupPayload}, "", http.StatusCreated, "", &expectedRequestBody}, t)
 		defer teardown()
 
@@ -331,8 +331,8 @@ func TestUpdateV3SecurityGroup(t *testing.T) {
 		  }`
 		buffer := new(bytes.Buffer)
 		err := json.Compact(buffer, []byte(requestBody))
-		buffer.Bytes()
-		expectedRequestBody := string(buffer.Bytes())
+		So(err, ShouldBeNil)
+		expectedRequestBody := buffer.String()
 		setup(MockRoute{"PATCH", "/v3/security_groups/guid-1", []string{genericV3SecurityGroupPayload}, "", http.StatusOK, "", &expectedRequestBody}, t)
 		defer teardown()
 

--- a/v3spaces.go
+++ b/v3spaces.go
@@ -191,6 +191,7 @@ type listV3SpaceUsersResponse struct {
 	Resources  []V3User   `json:"resources,omitempty"`
 }
 
+// ListV3SpaceUsers lists users by space GUID
 func (c *Client) ListV3SpaceUsers(spaceGUID string) ([]V3User, error) {
 	var users []V3User
 	requestURL := "/v3/spaces/" + spaceGUID + "/users"

--- a/v3spaces.go
+++ b/v3spaces.go
@@ -30,6 +30,16 @@ type UpdateV3SpaceRequest struct {
 	Metadata *V3Metadata
 }
 
+type V3SpaceUsers struct {
+	Name          string                         `json:"name,omitempty"`
+	GUID          string                         `json:"guid,omitempty"`
+	CreatedAt     string                         `json:"created_at,omitempty"`
+	UpdatedAt     string                         `json:"updated_at,omitempty"`
+	Relationships map[string]V3ToOneRelationship `json:"relationships,omitempty"`
+	Links         map[string]Link                `json:"links,omitempty"`
+	Metadata      V3Metadata                     `json:"metadata,omitempty"`
+}
+
 func (c *Client) CreateV3Space(r CreateV3SpaceRequest) (*V3Space, error) {
 	req := c.NewRequest("POST", "/v3/spaces")
 	params := map[string]interface{}{
@@ -174,4 +184,44 @@ func (c *Client) ListV3SpacesByQuery(query url.Values) ([]V3Space, error) {
 	}
 
 	return spaces, nil
+}
+
+type listV3SpaceUsersResponse struct {
+	Pagination Pagination `json:"pagination,omitempty"`
+	Resources  []V3User   `json:"resources,omitempty"`
+}
+
+func (c *Client) ListV3SpaceUsers(spaceGUID string) ([]V3User, error) {
+	var users []V3User
+	requestURL := "/v3/spaces/" + spaceGUID + "/users"
+
+	for {
+		r := c.NewRequest("GET", requestURL)
+		resp, err := c.DoRequest(r)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error requesting v3 space users")
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("Error listing v3 space users, response code: %d", resp.StatusCode)
+		}
+
+		var data listV3SpaceUsersResponse
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return nil, errors.Wrap(err, "Error parsing JSON from list v3 space users")
+		}
+		users = append(users, data.Resources...)
+
+		requestURL = data.Pagination.Next.Href
+		if requestURL == "" {
+			break
+		}
+		requestURL, err = extractPathFromURL(requestURL)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error parsing the next page request url for v3 space users")
+		}
+	}
+
+	return users, nil
 }

--- a/v3spaces_test.go
+++ b/v3spaces_test.go
@@ -116,3 +116,28 @@ func TestListV3SpacesByQuery(t *testing.T) {
 		So(spaces[1].Links["organization"].Href, ShouldEqual, "https://api.example.org/v3/organizations/org-guid")
 	})
 }
+
+func TestListV3SpaceUsersByQuery(t *testing.T) {
+	Convey("List V3 Space Users", t, func() {
+		setup(MockRoute{"GET", "/v3/spaces/space-guid/users", []string{listV3SpaceUsersPayload, listV3SpaceUsersPayloadPage2}, "", http.StatusOK, "", nil}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		users, err := client.ListV3SpaceUsers("space-guid")
+		So(err, ShouldBeNil)
+		So(users, ShouldHaveLength, 2)
+
+		So(users[0].Username, ShouldEqual, "some-name-1")
+		So(users[1].Username, ShouldEqual, "some-name-2")
+
+		So(users[0].PresentationName, ShouldEqual, "some-name-1")
+		So(users[0].Origin, ShouldEqual, "uaa")
+		So(users[0].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/users/10a93b89-3f89-4f05-7238-8a2b123c79l9")
+		So(users[1].PresentationName, ShouldEqual, "some-name-2")
+		So(users[1].Origin, ShouldEqual, "ldap")
+		So(users[1].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/users/9da93b89-3f89-4f05-7238-8a2b123c79l9")
+	})
+}

--- a/v3stacks.go
+++ b/v3stacks.go
@@ -1,0 +1,66 @@
+package cfclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+// V3Stack implements stack object. Stacks are the base operating system and file system that your application will execute in. A stack is how you configure applications to run against different operating systems (like Windows or Linux) and different versions of those operating systems.
+type V3Stack struct {
+	Name        string          `json:"name,omitempty"`
+	GUID        string          `json:"guid,omitempty"`
+	CreatedAt   string          `json:"created_at,omitempty"`
+	UpdatedAt   string          `json:"updated_at,omitempty"`
+	Description string          `json:"description,omitempty"`
+	Links       map[string]Link `json:"links,omitempty"`
+	Metadata    V3Metadata      `json:"metadata,omitempty"`
+}
+
+type listV3StacksResponse struct {
+	Pagination Pagination `json:"pagination,omitempty"`
+	Resources  []V3Stack  `json:"resources,omitempty"`
+}
+
+// ListV3StacksByQuery retrieves stacks based on query
+func (c *Client) ListV3StacksByQuery(query url.Values) ([]V3Stack, error) {
+	var stacks []V3Stack
+	requestURL, err := url.Parse("/v3/stacks")
+	if err != nil {
+		return nil, err
+	}
+	requestURL.RawQuery = query.Encode()
+
+	for {
+		r := c.NewRequest("GET", fmt.Sprintf("%s?%s", requestURL.Path, requestURL.RawQuery))
+		resp, err := c.DoRequest(r)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error requesting v3 stacks")
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("Error listing v3 stacks, response code: %d", resp.StatusCode)
+		}
+
+		var data listV3StacksResponse
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return nil, errors.Wrap(err, "Error parsing JSON from list v3 stacks")
+		}
+
+		stacks = append(stacks, data.Resources...)
+
+		requestURL, err = url.Parse(data.Pagination.Next.Href)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error parsing next page URL")
+		}
+		if requestURL.String() == "" {
+			break
+		}
+	}
+
+	return stacks, nil
+}

--- a/v3stacks_test.go
+++ b/v3stacks_test.go
@@ -1,0 +1,35 @@
+package cfclient
+
+import (
+	"net/http"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestListV3StacksByQuery(t *testing.T) {
+	Convey("List All V3 stacks", t, func() {
+		mocks := []MockRoute{
+			{"GET", "/v3/stacks", []string{listV3StacksPayload}, "", http.StatusOK, "", nil},
+		}
+		setupMultiple(mocks, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		stacks, err := client.ListV3StacksByQuery(nil)
+		So(err, ShouldBeNil)
+		So(stacks, ShouldHaveLength, 2)
+
+		So(stacks[0].Name, ShouldEqual, "my-stack-1")
+		So(stacks[0].Description, ShouldEqual, "This is my first stack!")
+		So(stacks[0].GUID, ShouldEqual, "guid-1")
+		So(stacks[0].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/stacks/guid-1")
+		So(stacks[1].Name, ShouldEqual, "my-stack-2")
+		So(stacks[1].Description, ShouldEqual, "This is my second stack!")
+		So(stacks[1].GUID, ShouldEqual, "guid-2")
+		So(stacks[1].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/stacks/guid-2")
+	})
+}

--- a/v3types.go
+++ b/v3types.go
@@ -16,10 +16,12 @@ type Link struct {
 	Method string `json:"method,omitempty"`
 }
 
+// V3ToOneRelationship is a relationship to a single object
 type V3ToOneRelationship struct {
 	Data V3Relationship `json:"data,omitempty"`
 }
 
+// V3ToManyRelationships is a relationship to multiple objects
 type V3ToManyRelationships struct {
 	Data []V3Relationship `json:"data,omitempty"`
 }

--- a/v3types.go
+++ b/v3types.go
@@ -20,6 +20,10 @@ type V3ToOneRelationship struct {
 	Data V3Relationship `json:"data,omitempty"`
 }
 
+type V3ToManyRelationships struct {
+	Data []V3Relationship `json:"data,omitempty"`
+}
+
 type V3Relationship struct {
 	GUID string `json:"guid,omitempty"`
 }

--- a/v3users.go
+++ b/v3users.go
@@ -1,5 +1,6 @@
 package cfclient
 
+// V3User implements the user object
 type V3User struct {
 	GUID             string          `json:"guid,omitempty"`
 	CreatedAt        string          `json:"created_at,omitempty"`

--- a/v3users.go
+++ b/v3users.go
@@ -1,0 +1,12 @@
+package cfclient
+
+type V3User struct {
+	GUID             string          `json:"guid,omitempty"`
+	CreatedAt        string          `json:"created_at,omitempty"`
+	UpdatedAt        string          `json:"updated_at,omitempty"`
+	Username         string          `json:"username,omitempty"`
+	PresentationName string          `json:"presentation_name,omitempty"`
+	Origin           string          `json:"origin,omitempty"`
+	Links            map[string]Link `json:"links,omitempty"`
+	Metadata         V3Metadata      `json:"metadata,omitempty"`
+}


### PR DESCRIPTION
# what
We are migrating our software to use v3 API and discovered that cfclient was missing some methods that we needed, so we decided to implement them. We have implemented only the ones that we use so the list of methods is still not complete. 
# how to test
- read the code and run `make test`
- share your thoughts :)
