### PR TITLE
Add `ListV3Routes` and `ListV3RoutesByQuery`

### DIFF
--- a/payloads_test.go
+++ b/payloads_test.go
@@ -4588,7 +4588,7 @@ const listV3AppsPayloadPage2 = `{
   ]
 }`
 
-const listV3ServiceInstances = `{
+const listV3ServiceInstancesPayload = `{
   "pagination": {
     "total_results": 1,
     "total_pages": 1,

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -4588,6 +4588,45 @@ const listV3AppsPayloadPage2 = `{
   ]
 }`
 
+const listV3ServiceInstances = `{
+  "pagination": {
+    "total_results": 1,
+    "total_pages": 1,
+    "first": {
+      "href": "https://api.example.org/v3/service_instances?page=1&per_page=50"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/service_instances?page=1&per_page=50"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "85ccdcad-d725-4109-bca4-fd6ba062b5c8",
+      "created_at": "2017-11-17T13:54:21Z",
+      "updated_at": "2017-11-17T13:54:21Z",
+      "name": "my_service_instance",
+      "relationships": {
+        "space": {
+          "data": {
+            "guid": "ae0031f9-dd49-461c-a945-df40e77c39cb"
+          }
+        }
+      },
+      "metadata": {
+        "labels": { },
+        "annotations": { }
+      },
+      "links": {
+        "space": {
+          "href": "https://api.example.org/v3/spaces/ae0031f9-dd49-461c-a945-df40e77c39cb"
+        }
+      }
+    }
+  ]
+}`
+
 const listPackagesForV3AppPayloadPage1 = `{
   "pagination": {
     "total_results": 2,

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -4627,6 +4627,61 @@ const listV3ServiceInstancesPayload = `{
   ]
 }`
 
+const listV3RoutesPayload = `{
+	"pagination": {
+	  "total_results": 1,
+	  "total_pages": 1,
+	  "first": {
+		"href": "https://api.example.org/v3/routes?page=1&per_page=1"
+	  },
+	  "last": {
+		"href": "https://api.example.org/v3/routes?page=1&per_page=1"
+	  },
+	  "next": null,
+	  "previous": null
+	},
+	"resources": [
+	  {
+		"guid": "cbad697f-cac1-48f4-9017-ac08f39dfb31",
+		"host": "a-hostname",
+		"path": "/some_path",
+		"url": "a-hostname.a-domain.com/some_path",
+		"created_at": "2019-05-10T17:17:48Z",
+		"updated_at": "2019-05-10T17:17:48Z",
+		"metadata": {
+		  "labels": {},
+		  "annotations": {}
+		},
+		"relationships": {
+		  "space": {
+			"data": {
+			  "guid": "885a8cb3-c07b-4856-b448-eeb10bf36236"
+			}
+		  },
+		  "domain": {
+			"data": {
+			  "guid": "0b5f3633-194c-42d2-9408-972366617e0e"
+			}
+		  }
+		},
+		"links": {
+		  "self": {
+			"href": "https://api.example.org/v3/routes/cbad697f-cac1-48f4-9017-ac08f39dfb31"
+		  },
+		  "space": {
+			"href": "https://api.example.org/v3/spaces/885a8cb3-c07b-4856-b448-eeb10bf36236"
+		  },
+		  "domain": {
+			"href": "https://api.example.org/v3/domains/0b5f3633-194c-42d2-9408-972366617e0e"
+		  },
+		  "destinations": {
+			"href": "https://api.example.org/v3/routes/cbad697f-cac1-48f4-9017-ac08f39dfb31/destinations"
+		  }
+		}
+	  }
+	]
+}`
+
 const listPackagesForV3AppPayloadPage1 = `{
   "pagination": {
     "total_results": 2,

--- a/v3route.go
+++ b/v3route.go
@@ -1,0 +1,71 @@
+package cfclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type V3Route struct {
+	Guid          string                         `json:"guid"`
+	Host          string                         `json:"host"`
+	Path          string                         `json:"path"`
+	Url           string                         `json:"url"`
+	CreatedAt     time.Time                      `json:"created_at"`
+	UpdatedAt     time.Time                      `json:"updated_at"`
+	Metadata      Metadata                       `json:"metadata"`
+	Relationships map[string]V3ToOneRelationship `json:"relationships"`
+	Links         map[string]Link                `json:"links"`
+}
+
+type listV3RouteResponse struct {
+	Pagination Pagination `json:"pagination,omitempty"`
+	Resources  []V3Route  `json:"resources,omitempty"`
+}
+
+func (c *Client) ListV3Routes() ([]V3Route, error) {
+	return c.ListV3RoutesByQuery(nil)
+}
+
+func (c *Client) ListV3RoutesByQuery(query url.Values) ([]V3Route, error) {
+	var routes []V3Route
+	requestURL := "/v3/routes"
+	if e := query.Encode(); len(e) > 0 {
+		requestURL += "?" + e
+	}
+
+	for {
+		r := c.NewRequest("GET", requestURL)
+		resp, err := c.DoRequest(r)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error requesting v3 service instances")
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("error listing v3 service instances, response code: %d", resp.StatusCode)
+		}
+
+		var data listV3RouteResponse
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return nil, errors.Wrap(err, "Error parsing JSON from list v3 service instances")
+		}
+
+		routes = append(routes, data.Resources...)
+
+		requestURL = data.Pagination.Next.Href
+		if requestURL == "" || query.Get("page") != "" {
+			break
+		}
+		requestURL, err = extractPathFromURL(requestURL)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error parsing the next page request url for v3 service instances")
+		}
+	}
+
+	return routes, nil
+}

--- a/v3route_test.go
+++ b/v3route_test.go
@@ -1,0 +1,35 @@
+package cfclient
+
+import (
+	"net/http"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestListV3Routes(t *testing.T) {
+	Convey("List V3 Routes", t, func() {
+		setup(MockRoute{"GET", "/v3/routes", []string{listV3RoutesPayload}, "", http.StatusOK, "", nil}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		routes, err := client.ListV3Routes()
+		So(err, ShouldBeNil)
+		So(routes, ShouldHaveLength, 1)
+
+		So(routes[0].Host, ShouldEqual, "a-hostname")
+		So(routes[0].Path, ShouldEqual, "/some_path")
+		So(routes[0].Url, ShouldEqual, "a-hostname.a-domain.com/some_path")
+
+		So(routes[0].Relationships["space"].Data.GUID, ShouldEqual, "885a8cb3-c07b-4856-b448-eeb10bf36236")
+		So(routes[0].Relationships["domain"].Data.GUID, ShouldEqual, "0b5f3633-194c-42d2-9408-972366617e0e")
+
+		So(routes[0].Links["self"].Href, ShouldEqual, "https://api.example.org/v3/routes/cbad697f-cac1-48f4-9017-ac08f39dfb31")
+		So(routes[0].Links["space"].Href, ShouldEqual, "https://api.example.org/v3/spaces/885a8cb3-c07b-4856-b448-eeb10bf36236")
+		So(routes[0].Links["domain"].Href, ShouldEqual, "https://api.example.org/v3/domains/0b5f3633-194c-42d2-9408-972366617e0e")
+		So(routes[0].Links["destinations"].Href, ShouldEqual, "https://api.example.org/v3/routes/cbad697f-cac1-48f4-9017-ac08f39dfb31/destinations")
+	})
+}

--- a/v3service_instances.go
+++ b/v3service_instances.go
@@ -1,0 +1,69 @@
+package cfclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type V3ServiceInstance struct {
+	Guid          string                         `json:"guid"`
+	CreatedAt     time.Time                      `json:"created_at"`
+	UpdatedAt     time.Time                      `json:"updated_at"`
+	Name          string                         `json:"name"`
+	Relationships map[string]V3ToOneRelationship `json:"relationships,omitempty"`
+	Metadata      Metadata                       `json:"metadata"`
+	Links         map[string]Link                `json:"links"`
+}
+
+type listV3ServiceInstancesResponse struct {
+	Pagination Pagination          `json:"pagination,omitempty"`
+	Resources  []V3ServiceInstance `json:"resources,omitempty"`
+}
+
+func (c *Client) ListV3ServiceInstances() ([]V3ServiceInstance, error) {
+	return c.ListV3ServiceInstancesByQuery(nil)
+}
+
+func (c *Client) ListV3ServiceInstancesByQuery(query url.Values) ([]V3ServiceInstance, error) {
+	var svcInstances []V3ServiceInstance
+	requestURL := "/v3/service_instances"
+	if e := query.Encode(); len(e) > 0 {
+		requestURL += "?" + e
+	}
+
+	for {
+		r := c.NewRequest("GET", requestURL)
+		resp, err := c.DoRequest(r)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error requesting v3 service instances")
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("error listing v3 service instances, response code: %d", resp.StatusCode)
+		}
+
+		var data listV3ServiceInstancesResponse
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return nil, errors.Wrap(err, "Error parsing JSON from list v3 service instances")
+		}
+
+		svcInstances = append(svcInstances, data.Resources...)
+
+		requestURL = data.Pagination.Next.Href
+		if requestURL == "" || query.Get("page") != "" {
+			break
+		}
+		requestURL, err = extractPathFromURL(requestURL)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error parsing the next page request url for v3 service instances")
+		}
+	}
+
+	return svcInstances, nil
+}

--- a/v3service_instances_test.go
+++ b/v3service_instances_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestListV3ServiceInstancesByQuery(t *testing.T) {
 	Convey("List V3 Service Instances", t, func() {
-		setup(MockRoute{"GET", "/v3/service_instances", []string{listV3ServiceInstances}, "", http.StatusOK, "", nil}, t)
+		setup(MockRoute{"GET", "/v3/service_instances", []string{listV3ServiceInstancesPayload}, "", http.StatusOK, "", nil}, t)
 		defer teardown()
 
 		c := &Config{ApiAddress: server.URL, Token: "foobar"}

--- a/v3service_instances_test.go
+++ b/v3service_instances_test.go
@@ -1,0 +1,28 @@
+package cfclient
+
+import (
+	"net/http"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestListV3ServiceInstancesByQuery(t *testing.T) {
+	Convey("List V3 Service Instances", t, func() {
+		setup(MockRoute{"GET", "/v3/service_instances", []string{listV3ServiceInstances}, "", http.StatusOK, "", nil}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		services, err := client.ListV3ServiceInstances()
+		So(err, ShouldBeNil)
+		So(services, ShouldHaveLength, 1)
+
+		So(services[0].Name, ShouldEqual, "my_service_instance")
+
+		So(services[0].Relationships["space"].Data.GUID, ShouldEqual, "ae0031f9-dd49-461c-a945-df40e77c39cb")
+		So(services[0].Links["space"].Href, ShouldEqual, "https://api.example.org/v3/spaces/ae0031f9-dd49-461c-a945-df40e77c39cb")
+	})
+}


### PR DESCRIPTION
Based on #300 
---

This PR adds the `ListV3Routes` method to reflect the List Routes functionality:
https://v3-apidocs.cloudfoundry.org/version/3.78.0/index.html#list-routes