### PR TITLE
Add support for listing service instances in a space

### DIFF
--- a/payloads_test.go
+++ b/payloads_test.go
@@ -702,6 +702,79 @@ const listSpacePeoplePayload = `{
   ]
 }`
 
+const listSpaceServiceInstancesPayload = `{
+  "total_results": 2,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "9547e9ed-e460-4abe-bda3-7070b9835917",
+        "url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917",
+        "created_at": "2016-06-08T16:41:41Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "name": "name-2104",
+        "credentials": {
+          "creds-key-60": "creds-val-60"
+        },
+        "service_plan_guid": "fcf57f7f-3c51-49b2-b252-dc24e0f7dcab",
+        "space_guid": "f858c6b3-f6b1-4ae8-81dd-8e8747657fbe",
+        "gateway_data": null,
+        "dashboard_url": null,
+        "type": "managed_service_instance",
+        "last_operation": null,
+        "tags": [
+
+        ],
+        "maintenance_info": {},
+        "space_url": "/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe",
+        "service_plan_url": "/v2/service_plans/fcf57f7f-3c51-49b2-b252-dc24e0f7dcab",
+        "service_bindings_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/service_bindings",
+        "service_keys_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/service_keys",
+        "routes_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/routes",
+        "shared_from_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/shared_from",
+        "shared_to_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/shared_to",
+        "service_instance_parameters_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/parameters"
+      }
+    },
+    {
+      "metadata": {
+        "guid": "07d2f44a-9031-11ec-b909-0242ac120002",
+        "url": "/v2/service_instances/07d2f44a-9031-11ec-b909-0242ac120002",
+        "created_at": "2016-07-08T16:41:41Z",
+        "updated_at": "2016-07-08T16:41:26Z"
+      },
+      "entity": {
+        "name": "name-2105",
+        "credentials": {
+          "creds-key-61": "creds-val-61"
+        },
+        "service_plan_guid": "22b3ae01-280d-41aa-9e97-68d47680003d",
+        "space_guid": "f858c6b3-f6b1-4ae8-81dd-8e8747657fbe",
+        "gateway_data": null,
+        "dashboard_url": null,
+        "type": "managed_service_instance",
+        "last_operation": null,
+        "tags": [
+
+        ],
+        "maintenance_info": {},
+        "space_url": "/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe",
+        "service_plan_url": "/v2/service_plans/22b3ae01-280d-41aa-9e97-68d47680003d",
+        "service_bindings_url": "/v2/service_instances/07d2f44a-9031-11ec-b909-0242ac120002/service_bindings",
+        "service_keys_url": "/v2/service_instances/07d2f44a-9031-11ec-b909-0242ac120002/service_keys",
+        "routes_url": "/v2/service_instances/07d2f44a-9031-11ec-b909-0242ac120002/routes",
+        "shared_from_url": "/v2/service_instances/07d2f44a-9031-11ec-b909-0242ac120002/shared_from",
+        "shared_to_url": "/v2/service_instances/07d2f44a-9031-11ec-b909-0242ac120002/shared_to",
+        "service_instance_parameters_url": "/v2/service_instances/07d2f44a-9031-11ec-b909-0242ac120002/parameters"
+      }
+    }
+  ]
+}`
+
 const spaceByGuidPayload = `{
   "metadata": {
     "guid": "8efd7c5c-d83c-4786-b399-b7bd548839e1",

--- a/spaces.go
+++ b/spaces.go
@@ -299,6 +299,29 @@ func (c *Client) ListSpaceDevelopers(spaceGUID string) ([]User, error) {
 	return c.ListSpaceDevelopersByQuery(spaceGUID, nil)
 }
 
+func (c *Client) ListSpaceServiceInstances(spaceGUID string) ([]ServiceInstance, error) {
+	return c.ListSpaceServiceInstancesByQuery(spaceGUID, nil)
+}
+
+func (c *Client) ListSpaceServiceInstancesByQuery(spaceGUID string, query url.Values) ([]ServiceInstance, error) {
+	var instances []ServiceInstance
+	requestURL := fmt.Sprintf("/v2/spaces/%s/service_instances?%s", spaceGUID, query.Encode())
+	for {
+		res, err := c.getServiceInstancesResponse(requestURL)
+		if err != nil {
+			return instances, err
+		}
+		for _, instance := range res.Resources {
+			instances = append(instances, c.mergeServiceInstance(instance))
+		}
+		requestURL = res.NextUrl
+		if requestURL == "" || query.Get("page") != "" {
+			break
+		}
+	}
+	return instances, nil
+}
+
 func (c *Client) AssociateSpaceDeveloper(spaceGUID, userGUID string) (Space, error) {
 	space := Space{Guid: spaceGUID, c: c}
 	return space.AssociateDeveloper(userGUID)

--- a/spaces_test.go
+++ b/spaces_test.go
@@ -48,6 +48,7 @@ func TestListSpaces(t *testing.T) {
 		So(spaces[3].OrganizationGuid, ShouldEqual, "da0dba14-6064-4f7a-b15a-ff9e677e49b2")
 	})
 }
+
 func TestListSpaceSecGroups(t *testing.T) {
 	Convey("List Space SecGroups", t, func() {
 		mocks := []MockRoute{
@@ -98,6 +99,7 @@ func TestListSpaceSecGroups(t *testing.T) {
 		So(secGroups[1].SpacesData[2].Entity.Name, ShouldEqual, "space-test3")
 	})
 }
+
 func TestListSpaceManagers(t *testing.T) {
 	Convey("ListSpaceManagers()", t, func() {
 		setup(MockRoute{"GET", "/v2/spaces/foo/managers", []string{listSpacePeoplePayload}, "", 200, "", nil}, t)
@@ -116,6 +118,7 @@ func TestListSpaceManagers(t *testing.T) {
 		So(users[1].Username, ShouldEqual, "user2")
 	})
 }
+
 func TestListSpaceAuditors(t *testing.T) {
 	Convey("ListSpaceAuditors()", t, func() {
 		setup(MockRoute{"GET", "/v2/spaces/foo/auditors", []string{listSpacePeoplePayload}, "", 200, "", nil}, t)
@@ -134,6 +137,7 @@ func TestListSpaceAuditors(t *testing.T) {
 		So(users[1].Username, ShouldEqual, "user2")
 	})
 }
+
 func TestListSpaceDevelopers(t *testing.T) {
 	Convey("ListSpaceDevelopers()", t, func() {
 		setup(MockRoute{"GET", "/v2/spaces/foo/developers", []string{listSpacePeoplePayload}, "", 200, "", nil}, t)
@@ -150,6 +154,60 @@ func TestListSpaceDevelopers(t *testing.T) {
 		So(len(users), ShouldEqual, 2)
 		So(users[0].Username, ShouldEqual, "user1")
 		So(users[1].Username, ShouldEqual, "user2")
+	})
+}
+
+func TestListSpaceServiceInstances(t *testing.T) {
+	Convey("ListSpaceServiceInstances()", t, func() {
+		setup(MockRoute{"GET", "/v2/spaces/494d8b64-8181-4183-a6d3-6279db8fec6e/service_instances", []string{listSpaceServiceInstancesPayload}, "", 200, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress: server.URL,
+			Token:      "foobar",
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		serviceInstances, err := client.ListSpaceServiceInstances("494d8b64-8181-4183-a6d3-6279db8fec6e")
+		So(err, ShouldBeNil)
+
+		So(len(serviceInstances), ShouldEqual, 2)
+		So(serviceInstances[0].Guid, ShouldEqual, "9547e9ed-e460-4abe-bda3-7070b9835917")
+		So(serviceInstances[0].Name, ShouldEqual, "name-2104")
+		So(serviceInstances[0].Credentials, ShouldHaveLength, 1)
+		So(serviceInstances[0].ServicePlanGuid, ShouldEqual, "fcf57f7f-3c51-49b2-b252-dc24e0f7dcab")
+		So(serviceInstances[0].SpaceGuid, ShouldEqual, "f858c6b3-f6b1-4ae8-81dd-8e8747657fbe")
+		So(serviceInstances[0].DashboardUrl, ShouldBeEmpty)
+		So(serviceInstances[0].Type, ShouldEqual, "managed_service_instance")
+		So(serviceInstances[0].Tags, ShouldBeEmpty)
+		So(serviceInstances[0].ServiceGuid, ShouldBeEmpty)
+		So(serviceInstances[0].ServiceInstanceParametersUrl, ShouldEqual, "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/parameters")
+		So(serviceInstances[0].SharedFromUrl, ShouldEqual, "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/shared_from")
+		So(serviceInstances[0].SharedToUrl, ShouldEqual, "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/shared_to")
+		So(serviceInstances[0].SpaceUrl, ShouldEqual, "/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe")
+		So(serviceInstances[0].ServicePlanUrl, ShouldEqual, "/v2/service_plans/fcf57f7f-3c51-49b2-b252-dc24e0f7dcab")
+		So(serviceInstances[0].ServiceBindingsUrl, ShouldEqual, "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/service_bindings")
+		So(serviceInstances[0].ServiceKeysUrl, ShouldEqual, "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/service_keys")
+		So(serviceInstances[0].RoutesUrl, ShouldEqual, "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/routes")
+		So(serviceInstances[0].ServiceUrl, ShouldEqual, "")
+		So(serviceInstances[1].Guid, ShouldEqual, "07d2f44a-9031-11ec-b909-0242ac120002")
+		So(serviceInstances[1].Name, ShouldEqual, "name-2105")
+		So(serviceInstances[1].Credentials, ShouldHaveLength, 1)
+		So(serviceInstances[1].ServicePlanGuid, ShouldEqual, "22b3ae01-280d-41aa-9e97-68d47680003d")
+		So(serviceInstances[1].SpaceGuid, ShouldEqual, "f858c6b3-f6b1-4ae8-81dd-8e8747657fbe")
+		So(serviceInstances[1].DashboardUrl, ShouldBeEmpty)
+		So(serviceInstances[1].Type, ShouldEqual, "managed_service_instance")
+		So(serviceInstances[1].Tags, ShouldBeEmpty)
+		So(serviceInstances[1].ServiceGuid, ShouldBeEmpty)
+		So(serviceInstances[1].ServiceInstanceParametersUrl, ShouldEqual, "/v2/service_instances/07d2f44a-9031-11ec-b909-0242ac120002/parameters")
+		So(serviceInstances[1].SharedFromUrl, ShouldEqual, "/v2/service_instances/07d2f44a-9031-11ec-b909-0242ac120002/shared_from")
+		So(serviceInstances[1].SharedToUrl, ShouldEqual, "/v2/service_instances/07d2f44a-9031-11ec-b909-0242ac120002/shared_to")
+		So(serviceInstances[1].SpaceUrl, ShouldEqual, "/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe")
+		So(serviceInstances[1].ServicePlanUrl, ShouldEqual, "/v2/service_plans/22b3ae01-280d-41aa-9e97-68d47680003d")
+		So(serviceInstances[1].ServiceBindingsUrl, ShouldEqual, "/v2/service_instances/07d2f44a-9031-11ec-b909-0242ac120002/service_bindings")
+		So(serviceInstances[1].ServiceKeysUrl, ShouldEqual, "/v2/service_instances/07d2f44a-9031-11ec-b909-0242ac120002/service_keys")
+		So(serviceInstances[1].RoutesUrl, ShouldEqual, "/v2/service_instances/07d2f44a-9031-11ec-b909-0242ac120002/routes")
+		So(serviceInstances[1].ServiceUrl, ShouldEqual, "")
 	})
 }
 


### PR DESCRIPTION
The v2 spaces api has a GET resource for retrieving all service instances
for a space that may behave more consistently than the v2 services instances
api that can be called with a space guid.