### PR TITLE
Add support for listing service credential bindings

### DIFF
--- a/payloads_test.go
+++ b/payloads_test.go
@@ -7433,3 +7433,92 @@ const listV3StacksPayload = `{
     }
   ]
 }`
+
+const listV3ServiceCredentialBindingsPayload = `{
+  "pagination": {
+    "total_results": 1,
+    "total_pages": 1,
+    "first": {
+      "href": "https://api.example.org/v3/service_instances?page=1&per_page=50"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/service_instances?page=1&per_page=50"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "d9634934-8e1f-4c2d-bb33-fa5df019cf9d",
+      "created_at": "2022-02-17T17:17:44Z",
+      "updated_at": "2022-02-17T17:17:44Z",
+      "name": "my_service_key",
+      "type": "key",
+      "relationships": {
+        "service_instance": {
+          "data": {
+              "guid": "85ccdcad-d725-4109-bca4-fd6ba062b5c8"
+          }
+        }
+      },
+      "metadata": {
+        "labels": { },
+        "annotations": { }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/service_credential_bindings/d9634934-8e1f-4c2d-bb33-fa5df019cf9d"
+        },
+        "details": {
+          "href": "https://api.example.org/v3/service_credential_bindings/d9634934-8e1f-4c2d-bb33-fa5df019cf9d/details"
+        },
+        "service_instance": {
+          "href": "https://api.example.org/v3/service_instances/85ccdcad-d725-4109-bca4-fd6ba062b5c8"
+        },
+        "parameters": {
+          "href": "https://api.example.org/v3/service_credential_bindings/d9634934-8e1f-4c2d-bb33-fa5df019cf9d/parameters"
+        }
+      }
+    }
+  ]
+}`
+
+const GetV3ServiceCredentialBindingsByGUIDPayload = `{
+  "guid": "d9634934-8e1f-4c2d-bb33-fa5df019cf9d",
+  "created_at": "2022-02-17T17:17:44Z",
+  "updated_at": "2022-02-17T17:17:44Z",
+  "name": "my_service_key",
+  "type": "key",
+  "last_operation": {
+    "type": "create",
+    "state": "succeeded",
+    "description": "",
+    "created_at": "2022-02-17T17:17:44Z",
+    "updated_at": "2022-02-17T17:17:44Z"
+  },
+  "relationships": {
+    "service_instance": {
+      "data": {
+        "guid": "85ccdcad-d725-4109-bca4-fd6ba062b5c8"
+      }
+    }
+  },
+  "metadata": {
+    "labels": { },
+    "annotations": { }
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/service_credential_bindings/d9634934-8e1f-4c2d-bb33-fa5df019cf9d"
+    },
+    "details": {
+      "href": "https://api.example.org/v3/service_credential_bindings/d9634934-8e1f-4c2d-bb33-fa5df019cf9d/details"
+    },
+    "service_instance": {
+      "href": "https://api.example.org/v3/service_instances/85ccdcad-d725-4109-bca4-fd6ba062b5c8"
+    },
+    "parameters": {
+      "href": "https://api.example.org/v3/service_credential_bindings/d9634934-8e1f-4c2d-bb33-fa5df019cf9d/parameters"
+    }
+  }
+}`

--- a/v3service_credential_bindings.go
+++ b/v3service_credential_bindings.go
@@ -1,0 +1,97 @@
+package cfclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// V3ServiceCredentialBindings implements the service credential binding object. a credential binding can be a binding between apps and a service instance or a service key
+type V3ServiceCredentialBindings struct {
+	GUID          string                         `json:"guid"`
+	CreatedAt     time.Time                      `json:"created_at"`
+	UpdatedAt     time.Time                      `json:"updated_at"`
+	Name          string                         `json:"name"`
+	Type          string                         `json:"type"`
+	LastOperation LastOperation                  `json:"last_operation"`
+	Metadata      Metadata                       `json:"metadata"`
+	Relationships map[string]V3ToOneRelationship `json:"relationships,omitempty"`
+	Links         map[string]Link                `json:"links"`
+}
+
+type listV3ServiceCredentialBindingsResponse struct {
+	Pagination Pagination                    `json:"pagination,omitempty"`
+	Resources  []V3ServiceCredentialBindings `json:"resources,omitempty"`
+}
+
+// ListV3ServiceCredentialBindings retrieves all service credential bindings
+func (c *Client) ListV3ServiceCredentialBindings() ([]V3ServiceCredentialBindings, error) {
+	return c.ListV3ServiceCredentialBindingsByQuery(nil)
+}
+
+// ListV3ServiceCredentialBindingsByQuery retrieves service credential bindings using a query
+func (c *Client) ListV3ServiceCredentialBindingsByQuery(query url.Values) ([]V3ServiceCredentialBindings, error) {
+	var svcCredentialBindings []V3ServiceCredentialBindings
+	requestURL := "/v3/service_credential_bindings"
+	if e := query.Encode(); len(e) > 0 {
+		requestURL += "?" + e
+	}
+
+	for {
+		r := c.NewRequest("GET", requestURL)
+		resp, err := c.DoRequest(r)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error requesting v3 service credential bindings")
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("error listing v3 service credential bindings, response code: %d", resp.StatusCode)
+		}
+
+		var data listV3ServiceCredentialBindingsResponse
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return nil, errors.Wrap(err, "Error parsing JSON from list v3 service credential bindings")
+		}
+
+		svcCredentialBindings = append(svcCredentialBindings, data.Resources...)
+
+		requestURL = data.Pagination.Next.Href
+		if requestURL == "" || query.Get("page") != "" {
+			break
+		}
+		requestURL, err = extractPathFromURL(requestURL)
+		if err != nil {
+			return nil, errors.Wrap(err, "Error parsing the next page request url for v3 service credential bindings")
+		}
+	}
+
+	return svcCredentialBindings, nil
+}
+
+// GetV3ServiceCredentialBindingsByGUID retrieves the service credential binding based on the provided guid
+func (c *Client) GetV3ServiceCredentialBindingsByGUID(GUID string) (*V3ServiceCredentialBindings, error) {
+	requestURL := fmt.Sprintf("/v3/service_credential_bindings/%s", GUID)
+	req := c.NewRequest("GET", requestURL)
+	resp, err := c.DoRequest(req)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "Error while getting v3 service credential binding")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Error getting v3 service credential binding with GUID [%s], response code: %d", GUID, resp.StatusCode)
+	}
+
+	var svcCredentialBindings V3ServiceCredentialBindings
+	if err := json.NewDecoder(resp.Body).Decode(&svcCredentialBindings); err != nil {
+		return nil, errors.Wrap(err, "Error reading v3 service credential binding JSON")
+	}
+
+	return &svcCredentialBindings, nil
+}

--- a/v3service_credential_bindings_test.go
+++ b/v3service_credential_bindings_test.go
@@ -1,0 +1,51 @@
+package cfclient
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestListV3ServiceCredentialBindingsByQuery(t *testing.T) {
+	Convey("List V3 Service Credential Bindings", t, func() {
+		setup(MockRoute{"GET", "/v3/service_credential_bindings", []string{listV3ServiceCredentialBindingsPayload}, "", http.StatusOK, "", nil}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		serviceCredentialsBindings, err := client.ListV3ServiceCredentialBindings()
+		So(err, ShouldBeNil)
+		So(serviceCredentialsBindings, ShouldHaveLength, 1)
+
+		So(serviceCredentialsBindings[0].Name, ShouldEqual, "my_service_key")
+		So(serviceCredentialsBindings[0].Type, ShouldEqual, "key")
+
+		So(serviceCredentialsBindings[0].Relationships["service_instance"].Data.GUID, ShouldEqual, "85ccdcad-d725-4109-bca4-fd6ba062b5c8")
+		So(serviceCredentialsBindings[0].Links["service_instance"].Href, ShouldEqual, "https://api.example.org/v3/service_instances/85ccdcad-d725-4109-bca4-fd6ba062b5c8")
+	})
+}
+
+func TestGetV3ServiceCredentialBindingsByGUID(t *testing.T) {
+	Convey("Get V3 Service Credential Binding by GUID", t, func() {
+		GUID := "d9634934-8e1f-4c2d-bb33-fa5df019cf9d"
+		setup(MockRoute{"GET", fmt.Sprintf("/v3/service_credential_bindings/%s", GUID), []string{GetV3ServiceCredentialBindingsByGUIDPayload}, "", http.StatusOK, "", nil}, t)
+		defer teardown()
+
+		c := &Config{ApiAddress: server.URL, Token: "foobar"}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+
+		serviceCredentialsBinding, err := client.GetV3ServiceCredentialBindingsByGUID(GUID)
+		So(err, ShouldBeNil)
+
+		So(serviceCredentialsBinding.Name, ShouldEqual, "my_service_key")
+		So(serviceCredentialsBinding.Type, ShouldEqual, "key")
+
+		So(serviceCredentialsBinding.Relationships["service_instance"].Data.GUID, ShouldEqual, "85ccdcad-d725-4109-bca4-fd6ba062b5c8")
+		So(serviceCredentialsBinding.Links["service_instance"].Href, ShouldEqual, "https://api.example.org/v3/service_instances/85ccdcad-d725-4109-bca4-fd6ba062b5c8")
+	})
+}


### PR DESCRIPTION
The v2 api only supports 2 query parameters for service key : name and service_instance_guid. The endpoint becomes service_credential_bindings in v3 and supports more query parameters.