### PR TITLE
Add destinations to V3 Routes Struct

### DIFF
--- a/v3routes.go
+++ b/v3routes.go
@@ -29,9 +29,9 @@ type listV3RouteResponse struct {
 }
 
 type Destination struct {
-	Guid string `json:"guid"`
+	GUID string `json:"guid"`
 	App  struct {
-		Guid    string `json:"guid"`
+		GUID    string `json:"guid"`
 		Process struct {
 			Type string `json:"type"`
 		} `json:"process"`

--- a/v3routes.go
+++ b/v3routes.go
@@ -18,6 +18,7 @@ type V3Route struct {
 	CreatedAt     time.Time                      `json:"created_at"`
 	UpdatedAt     time.Time                      `json:"updated_at"`
 	Metadata      Metadata                       `json:"metadata"`
+	Destinations  []Destination                  `json:"destinations"`
 	Relationships map[string]V3ToOneRelationship `json:"relationships"`
 	Links         map[string]Link                `json:"links"`
 }
@@ -25,6 +26,19 @@ type V3Route struct {
 type listV3RouteResponse struct {
 	Pagination Pagination `json:"pagination,omitempty"`
 	Resources  []V3Route  `json:"resources,omitempty"`
+}
+
+type Destination struct {
+	Guid string `json:"guid"`
+	App  struct {
+		Guid    string `json:"guid"`
+		Process struct {
+			Type string `json:"type"`
+		} `json:"process"`
+	} `json:"app"`
+	Weight   interface{} `json:"weight"`
+	Port     int         `json:"port"`
+	Protocol string      `json:"protocol"`
 }
 
 func (c *Client) ListV3Routes() ([]V3Route, error) {


### PR DESCRIPTION
The V3Route struct was missing the destination array, as described in #317


The routes object does contain a destination array linking target apps of domains, would be good to also have this accessible through the struct.
https://v3-apidocs.cloudfoundry.org/version/3.126.0/index.html#the-route-object