### PR TITLE
Process Stats by App GUID

### DIFF
--- a/client/process.go
+++ b/client/process.go
@@ -2,8 +2,9 @@ package client
 
 import (
 	"context"
-	"github.com/cloudfoundry-community/go-cfclient/v3/internal/path"
 	"net/url"
+
+	"github.com/cloudfoundry-community/go-cfclient/v3/internal/path"
 
 	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
 )
@@ -58,6 +59,16 @@ func (c *ProcessClient) Get(ctx context.Context, guid string) (*resource.Process
 func (c *ProcessClient) GetStats(ctx context.Context, guid string) (*resource.ProcessStats, error) {
 	var stats resource.ProcessStats
 	err := c.client.get(ctx, path.Format("/v3/processes/%s/stats", guid), &stats)
+	if err != nil {
+		return nil, err
+	}
+	return &stats, nil
+}
+
+// GetStatsApp for the specified app
+func (c *ProcessClient) GetStatsApp(ctx context.Context, guid, processType string) (*resource.ProcessStats, error) {
+	var stats resource.ProcessStats
+	err := c.client.get(ctx, path.Format("/v3/apps/%s/processes/%s/stats", guid, processType), &stats)
 	if err != nil {
 		return nil, err
 	}

--- a/client/process_test.go
+++ b/client/process_test.go
@@ -2,10 +2,11 @@ package client
 
 import (
 	"context"
-	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
-	"github.com/cloudfoundry-community/go-cfclient/v3/testutil"
 	"net/http"
 	"testing"
+
+	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
+	"github.com/cloudfoundry-community/go-cfclient/v3/testutil"
 )
 
 func TestProcesses(t *testing.T) {
@@ -41,6 +42,19 @@ func TestProcesses(t *testing.T) {
 			Expected: processStats,
 			Action: func(c *Client, t *testing.T) (any, error) {
 				return c.Processes.GetStats(context.Background(), "ec4ff362-60c5-47a0-8246-2a134537c606")
+			},
+		},
+		{
+			Description: "Get app process stats",
+			Route: testutil.MockRoute{
+				Method:   "GET",
+				Endpoint: "/v3/apps/2a550283-9245-493e-af36-5e4b8703f896/processes/web/stats",
+				Output:   g.Single(processStats),
+				Status:   http.StatusOK,
+			},
+			Expected: processStats,
+			Action: func(c *Client, t *testing.T) (any, error) {
+				return c.Processes.GetStatsApp(context.Background(), "2a550283-9245-493e-af36-5e4b8703f896", "web")
 			},
 		},
 		{


### PR DESCRIPTION
I hope the process section of the client is the correct place to put this. Otherwise we may add a file for stats or put this into the app section.

GET /v3/apps/:guid/processes/:type/stats

[V3 API](https://v3-apidocs.cloudfoundry.org/version/3.143.0/index.html#get-stats-for-a-process)

#343 