### PR TITLE
Enhance multiple auth support and auth client

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,10 +1,11 @@
 package config
 
 import (
-	"github.com/cloudfoundry-community/go-cfclient/v3/testutil"
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/cloudfoundry-community/go-cfclient/v3/testutil"
 
 	"github.com/stretchr/testify/require"
 )
@@ -39,7 +40,7 @@ func TestUsernamePassword(t *testing.T) {
 		require.Equal(t, "username", c.username)
 		require.Equal(t, "password", c.password)
 		require.Equal(t, "cf", c.clientID)
-		require.Equal(t, GrantTypeAuthorizationCode, c.grantType)
+		require.Equal(t, GrantTypePassword, c.grantType)
 	})
 
 	t.Run("with username and password with non-default client", func(t *testing.T) {
@@ -53,7 +54,7 @@ func TestUsernamePassword(t *testing.T) {
 		require.Equal(t, "username", c.username)
 		require.Equal(t, "password", c.password)
 		require.Equal(t, "clientID", c.clientID)
-		require.Equal(t, GrantTypeAuthorizationCode, c.grantType)
+		require.Equal(t, GrantTypePassword, c.grantType)
 	})
 }
 
@@ -198,7 +199,7 @@ func TestNewConfigFromCFHomeDir(t *testing.T) {
 		require.Equal(t, "admin", cfg.username)
 		require.Equal(t, "pass", cfg.password)
 		require.Equal(t, DefaultClientID, cfg.clientID)
-		require.Equal(t, GrantTypeAuthorizationCode, cfg.grantType)
+		require.Equal(t, GrantTypePassword, cfg.grantType)
 	})
 
 	t.Run("with override options", func(t *testing.T) {
@@ -213,6 +214,6 @@ func TestNewConfigFromCFHomeDir(t *testing.T) {
 		require.Equal(t, "admin", cfg.username)
 		require.Equal(t, "pass", cfg.password)
 		require.Equal(t, DefaultClientID, cfg.clientID)
-		require.Equal(t, GrantTypeAuthorizationCode, cfg.grantType)
+		require.Equal(t, GrantTypePassword, cfg.grantType)
 	})
 }


### PR DESCRIPTION
In this Pull Request, I've implemented enhancements to address a specific limitation: 

1. While the user password grant type previously supported only the default client (cf), it now accommodates the use of alternative clients, which was not possible before. Now we can achieve like below

```go
config.New("https://api.cf.com", config.ClientCredentials('test', 'test'), config.UserPassword('test', 'test'))
```

2. At present, duplication of the client request body occurs when utilizing `bytes.Buffer`, `bytes.Reader`, and `strings.Reader`.

3. Reattempt the client request following the expiration of the refresh token.

4. Eliminate the use of loops in implementing retry logic.