### PR TITLE
Adjust the page limit in the 'Single' and 'First' pager functions to enhance the efficiency of data retrieval

### DIFF
--- a/client/app_test.go
+++ b/client/app_test.go
@@ -2,11 +2,13 @@ package client
 
 import (
 	"context"
-	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
-	"github.com/cloudfoundry-community/go-cfclient/v3/testutil"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
+	"github.com/cloudfoundry-community/go-cfclient/v3/testutil"
 )
 
 func TestApps(t *testing.T) {
@@ -58,7 +60,7 @@ func TestApps(t *testing.T) {
 			Route: testutil.MockRoute{
 				Method:      "GET",
 				Endpoint:    "/v3/apps",
-				QueryString: "names=spring-music&page=1&per_page=50",
+				QueryString: "names=spring-music&page=1&per_page=1",
 				Output:      g.Paged([]string{app1, app2}),
 				Status:      http.StatusOK},
 			Expected: app1,
@@ -73,7 +75,7 @@ func TestApps(t *testing.T) {
 			Route: testutil.MockRoute{
 				Method:      "GET",
 				Endpoint:    "/v3/apps",
-				QueryString: "names=spring-music&page=1&per_page=50",
+				QueryString: "names=spring-music&page=1&per_page=1",
 				Output:      g.Paged([]string{}),
 				Status:      http.StatusOK},
 			Action: func(c *Client, t *testing.T) (any, error) {
@@ -230,7 +232,7 @@ func TestApps(t *testing.T) {
 			Route: testutil.MockRoute{
 				Method:      "GET",
 				Endpoint:    "/v3/apps",
-				QueryString: "names=spring-music-124&page=1&per_page=50",
+				QueryString: "names=spring-music-124&page=1&per_page=2",
 				Output:      g.Paged([]string{app1}),
 				Status:      http.StatusOK},
 			Expected: app1,
@@ -245,7 +247,7 @@ func TestApps(t *testing.T) {
 			Route: testutil.MockRoute{
 				Method:      "GET",
 				Endpoint:    "/v3/apps",
-				QueryString: "names=spring-music&page=1&per_page=50",
+				QueryString: "names=spring-music&page=1&per_page=2",
 				Output:      g.Paged([]string{app1, app2}),
 				Status:      http.StatusOK},
 			Action: func(c *Client, t *testing.T) (any, error) {

--- a/client/list_opt.go
+++ b/client/list_opt.go
@@ -25,6 +25,7 @@ var listOptionsSerializerType = reflect.TypeOf((*ListOptionsSerializer)(nil)).El
 type ListOptioner interface {
 	CurrentPage(page, perPage int)
 	ToQueryString() (url.Values, error)
+	SetPerPage(perPage int)
 }
 
 // ListOptions is the shared common type for all other list option types
@@ -47,6 +48,10 @@ func NewListOptions() *ListOptions {
 
 func (lo *ListOptions) CurrentPage(page, perPage int) {
 	lo.Page = page
+	lo.PerPage = perPage
+}
+
+func (lo *ListOptions) SetPerPage(perPage int) {
 	lo.PerPage = perPage
 }
 

--- a/client/pager.go
+++ b/client/pager.go
@@ -74,6 +74,7 @@ func AutoPage[T ListOptioner, R any](opts T, list ListFunc[T, R]) ([]R, error) {
 
 // Single returns a single object from the call to list or an error if matches > 1 or matches < 1
 func Single[T ListOptioner, R any](opts T, list ListFunc[T, R]) (R, error) {
+	opts.SetPerPage(2)
 	matches, _, err := list(opts)
 	if err != nil {
 		return *new(R), err
@@ -86,6 +87,7 @@ func Single[T ListOptioner, R any](opts T, list ListFunc[T, R]) (R, error) {
 
 // First returns the first object from the call to list or an error if matches < 1
 func First[T ListOptioner, R any](opts T, list ListFunc[T, R]) (R, error) {
+	opts.SetPerPage(1)
 	matches, _, err := list(opts)
 	if err != nil {
 		return *new(R), err


### PR DESCRIPTION
The modification involves adjusting the page limit settings in the 'Single' and 'First' paging functions. This change aims to optimize performance and enhance the efficiency of data retrieval operations.