### PR TITLE
fix: expose apiEndpointURL

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -196,6 +196,11 @@ func (c *Config) UserAgent() string {
 	return c.userAgent
 }
 
+// ApiEndpointURL returns the configured api endpoint url string.
+func (c *Config) ApiEndpointURL() string {
+	return c.apiEndpointURL
+}
+
 // Validate returns an error if the Config is incomplete or invalid.
 func (c *Config) Validate() error {
 	if !c.initialized {


### PR DESCRIPTION
A minor change to expose configured apiEndpointURL.
With [this](https://github.com/cloudfoundry-community/go-cfclient/commit/f43d2663d6f341969f3b19660eb7f690192e6d4c) change we stop exposing the config attributes directly, so now individual getters would be needed for cases like NewFromCFHome