### PR TITLE
Add fix for issue #378

### DIFF
--- a/resource/security_group.go
+++ b/resource/security_group.go
@@ -32,8 +32,8 @@ type SecurityGroupUpdate struct {
 
 // SecurityGroupGloballyEnabled object controls if the group is applied globally to the lifecycle of all applications
 type SecurityGroupGloballyEnabled struct {
-	Running bool `json:"running"`
-	Staging bool `json:"staging"`
+	Running *bool `json:"running,omitempty"`
+	Staging *bool `json:"staging,omitempty"`
 }
 
 type SecurityGroupsRelationships struct {

--- a/testutil/pointer.go
+++ b/testutil/pointer.go
@@ -1,0 +1,13 @@
+package testutil
+
+func BoolPtr(b bool) *bool {
+	return &b
+}
+
+func IntPtr(i int) *int {
+	return &i
+}
+
+func StringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
Globally enabled running and staging flags should be optional for security groups allowing only the security group name or rule definitions to be updated.