### PR TITLE
IncludeSpace string capitalization causes CF-BadQueryParameter

### DIFF
--- a/resource/types.go
+++ b/resource/types.go
@@ -7,7 +7,7 @@ import (
 const (
 	IncludeNone              = ""
 	IncludeSpaceOrganization = "space.organization"
-	IncludeSpace             = "Space"
+	IncludeSpace             = "space"
 	IncludeUser              = "user"
 	IncludeOrganization      = "organization"
 	IncludeDomain            = "domain"


### PR DESCRIPTION
Before this change, running AppClient.ListIncludeSpaces results in error `CF-BadQueryParameter|10005: The query parameter is invalid: Invalid included resource: 'Space'. Valid included resources are: 'space', 'org', 'space.organization'`.