### PR TITLE
fix: jwt bearer durability

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,22 @@ cfg, _ := config.New("https://api.example.org",config.JWTBearerAssertion("jwt-as
 cf, _ := client.New(cfg)
 ```
 
+The assertion is exchanged with UAA exactly once, at `config.New` time.
+If UAA issues a refresh token (the standard configuration), subsequent
+API calls use the cached access token and refresh it via the
+refresh-token grant — the assertion is never presented again. This means
+the client survives long-running operations (e.g. a Terraform apply with
+polling) even when the assertion's lifetime is only a few minutes, as
+long as the refresh token's lifetime covers the run.
+
+If the UAA client is configured to *not* issue a refresh token for the
+jwt-bearer grant, the client can only operate until the access token
+expires; after that, calls fail with a diagnostic and a fresh assertion
+must be supplied. Check `refresh_token_validity` and the
+`authorized_grant_types` (which must include both
+`urn:ietf:params:oauth:grant-type:jwt-bearer` and `refresh_token`) on
+the UAA client when planning long-running uses.
+
 For more detailed examples of using the various authentication and configuration options, see the
 [auth example](./examples/auth/main.go).
 

--- a/config/config.go
+++ b/config/config.go
@@ -173,10 +173,10 @@ func (c *Config) CreateOAuth2TokenSource(ctx context.Context) (oauth2.TokenSourc
 		authConfig := threeLeggedAuthConfigFn()
 		tokenSource = authConfig.TokenSource(oauthCtx, c.oAuthToken)
 	case GrantTypeJwtBearer:
-		var uaaEndpointURL string
+		uaaEndpointURL := c.uaaEndpointURL + "/oauth/token"
 		if c.origin != "" {
 			// Add optional login hint to the token URL
-			uaaEndpointURL = addLoginHintToURL(c.uaaEndpointURL+"/oauth/token", c.origin)
+			uaaEndpointURL = addLoginHintToURL(uaaEndpointURL, c.origin)
 		}
 		tokenSource = &jwt.JWTAssertionTokenSource{
 			Assertion:       c.assertion,

--- a/config/config.go
+++ b/config/config.go
@@ -178,7 +178,7 @@ func (c *Config) CreateOAuth2TokenSource(ctx context.Context) (oauth2.TokenSourc
 			// Add optional login hint to the token URL
 			uaaEndpointURL = addLoginHintToURL(uaaEndpointURL, c.origin)
 		}
-		tokenSource = &jwt.JWTAssertionTokenSource{
+		exchanger := &jwt.JWTAssertionTokenSource{
 			Assertion:       c.assertion,
 			ClientAssertion: c.clientAssertion,
 			TokenURL:        uaaEndpointURL,
@@ -186,6 +186,28 @@ func (c *Config) CreateOAuth2TokenSource(ctx context.Context) (oauth2.TokenSourc
 			ClientSecret:    c.clientSecret,
 			HTTPClient:      c.httpClient,
 			Scopes:          c.scopes,
+		}
+		// Eagerly exchange the (short-lived) assertion for an access token, mirroring
+		// how the password grant calls PasswordCredentialsToken at config-init time.
+		// This surfaces a bad/expired assertion at config.New(...) instead of on the
+		// first authenticated API call.
+		token, err := exchanger.Token()
+		if err != nil {
+			return nil, fmt.Errorf("jwt-bearer assertion exchange failed: %w", err)
+		}
+		if token.RefreshToken != "" {
+			// Hand off to the standard refresh-token flow: the access token is cached
+			// until expiry and refreshed using refresh_token, never re-presenting the
+			// assertion (which is typically only valid for a few minutes).
+			authConfig := threeLeggedAuthConfigFn()
+			tokenSource = authConfig.TokenSource(oauthCtx, token)
+		} else {
+			// UAA returned no refresh_token. There is no durable credential to live
+			// off; once the access token expires, the only remedy is reconfiguring
+			// the client with a fresh assertion. Wrap so the access token is reused
+			// until expiry, then surface a clear diagnostic instead of silently
+			// re-presenting the (likely expired) assertion.
+			tokenSource = oauth2.ReuseTokenSource(token, expiredJwtBearerSource{})
 		}
 	default:
 		return nil, fmt.Errorf("unsupported OAuth2 grant type '%s'", c.grantType)
@@ -403,4 +425,15 @@ func addLoginHintToURL(tokenURL, origin string) string {
 	u.RawQuery = q.Encode()
 
 	return u.String()
+}
+
+// expiredJwtBearerSource is the inner source for ReuseTokenSource on the
+// jwt-bearer flow when UAA did not issue a refresh token. Once the cached
+// access token expires, oauth2.ReuseTokenSource calls Token() on this and we
+// surface a diagnostic error instead of silently re-presenting the (now
+// likely expired) original assertion.
+type expiredJwtBearerSource struct{}
+
+func (expiredJwtBearerSource) Token() (*oauth2.Token, error) {
+	return nil, errors.New("jwt-bearer access token expired and no refresh token was issued by UAA; reconfigure the client with a fresh assertion")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -292,6 +292,18 @@ func setGrantType(c *Config) error {
 	case c.username != "" && c.password != "":
 		c.grantType = GrantTypePassword
 	case c.assertion != "":
+		// The jwt-bearer flow does an eager exchange and then hands off to the
+		// refresh-token grant via oauth2.Config.TokenSource, which authenticates
+		// refreshes using only client_id / client_secret. A ClientAssertion
+		// supplied alongside a user assertion would be honored on the initial
+		// exchange but silently dropped on every subsequent refresh — if UAA
+		// requires client_assertion auth, refreshes would then fail at runtime.
+		// Reject the combination up front so the failure mode is loud.
+		if c.clientAssertion != "" {
+			return errors.New("client assertion is not supported with the JWT Bearer assertion grant: " +
+				"the refresh-token handoff cannot replay the client assertion, so refreshes would silently " +
+				"fall back to client_id/client_secret auth")
+		}
 		c.grantType = GrantTypeJwtBearer
 	case c.clientID != "" && (c.clientSecret != "" || c.clientAssertion != ""):
 		c.grantType = GrantTypeClientCredentials

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,10 +1,12 @@
 package config
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"testing"
 
+	"github.com/cloudfoundry/go-cfclient/v3/internal/jwt"
 	"github.com/cloudfoundry/go-cfclient/v3/testutil"
 
 	"github.com/stretchr/testify/require"
@@ -246,5 +248,36 @@ func TestJwBearerAssertion(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, jwtAssertion, cfg.assertion)
 		require.Equal(t, GrantTypeJwtBearer, cfg.grantType)
+	})
+
+	t.Run("TokenURL is set when origin is empty", func(t *testing.T) {
+		// Regression: previously TokenURL was only assigned when origin was set,
+		// so the eventual Token() call failed with "token URL is required".
+		cfg, err := New("https://api.example.com",
+			JWTBearerAssertion(jwtAssertion),
+			AuthTokenURL("https://login.cf.example.com", "https://token.cf.example.com"))
+		require.NoError(t, err)
+
+		src, err := cfg.CreateOAuth2TokenSource(context.Background())
+		require.NoError(t, err)
+		jwtSrc, ok := src.(*jwt.JWTAssertionTokenSource)
+		require.True(t, ok, "expected *jwt.JWTAssertionTokenSource, got %T", src)
+		require.Equal(t, "https://token.cf.example.com/oauth/token", jwtSrc.TokenURL)
+	})
+
+	t.Run("TokenURL has login_hint when origin is set", func(t *testing.T) {
+		cfg, err := New("https://api.example.com",
+			JWTBearerAssertion(jwtAssertion),
+			Origin("my-idp"),
+			AuthTokenURL("https://login.cf.example.com", "https://token.cf.example.com"))
+		require.NoError(t, err)
+
+		src, err := cfg.CreateOAuth2TokenSource(context.Background())
+		require.NoError(t, err)
+		jwtSrc, ok := src.(*jwt.JWTAssertionTokenSource)
+		require.True(t, ok, "expected *jwt.JWTAssertionTokenSource, got %T", src)
+		require.Contains(t, jwtSrc.TokenURL, "https://token.cf.example.com/oauth/token")
+		require.Contains(t, jwtSrc.TokenURL, "login_hint")
+		require.Contains(t, jwtSrc.TokenURL, "my-idp")
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -345,4 +345,17 @@ func TestJwBearerAssertion(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "jwt-bearer assertion exchange failed")
 	})
+
+	t.Run("rejects ClientAssertion combined with JWTBearerAssertion", func(t *testing.T) {
+		// The refresh-token handoff cannot replay a ClientAssertion: refreshes
+		// would silently fall back to client_id/client_secret auth and fail at
+		// runtime if UAA requires client_assertion. Reject up front.
+		_, err := New("https://api.example.com",
+			JWTBearerAssertion(validAssertion),
+			ClientCredentials("clientID", ""),
+			ClientAssertion(clientAssertion),
+			AuthTokenURL("https://login.cf.example.com", "https://token.cf.example.com"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "client assertion is not supported with the JWT Bearer assertion grant")
+	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"context"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -15,7 +17,6 @@ import (
 const accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6InRlc3QgY2YgdG9rZW4iLCJpYXQiOjE1MTYyMzkwMjIsImV4cCI6MTUxNjIzOTAyMn0.mLvUvu-ED_lIkyI3UTXS_hUEPPFdI0BdNqRMgMThAhk"
 const refreshToken = "secret-refresh-token"
 const clientAssertion = "client-assertion-token"
-const jwtAssertion = "jwt-assertion-token"
 
 func TestInvalidConfig(t *testing.T) {
 	c := &Config{}
@@ -241,43 +242,107 @@ func TestNewConfigFromCFHomeDir(t *testing.T) {
 }
 
 func TestJwBearerAssertion(t *testing.T) {
-	t.Run("minimalistic setup", func(t *testing.T) {
+	// A syntactically valid JWT (three base64url segments). The fake UAA
+	// server in testutil does not verify the assertion's signature or
+	// claims, so this is sufficient for exercising the exchange flow.
+	const validAssertion = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.c2ln"
+
+	t.Run("eager exchange populates oAuth state", func(t *testing.T) {
+		uaaURL := testutil.SetupFakeUAAServer(300)
 		cfg, err := New("https://api.example.com",
-			JWTBearerAssertion(jwtAssertion),
-			AuthTokenURL("https://login.cf.example.com", "https://token.cf.example.com")) // skip service discovery
+			JWTBearerAssertion(validAssertion),
+			AuthTokenURL(uaaURL, uaaURL))
 		require.NoError(t, err)
-		require.Equal(t, jwtAssertion, cfg.assertion)
+		require.Equal(t, validAssertion, cfg.assertion)
 		require.Equal(t, GrantTypeJwtBearer, cfg.grantType)
 	})
 
-	t.Run("TokenURL is set when origin is empty", func(t *testing.T) {
-		// Regression: previously TokenURL was only assigned when origin was set,
-		// so the eventual Token() call failed with "token URL is required".
+	t.Run("hands off to refresh-token flow when UAA issues a refresh_token", func(t *testing.T) {
+		// SetupFakeUAAServer always returns a refresh_token. The token
+		// source returned by CreateOAuth2TokenSource should therefore be
+		// the standard oauth2 reuse-source over the refresh-token grant,
+		// not a *jwt.JWTAssertionTokenSource.
+		uaaURL := testutil.SetupFakeUAAServer(300)
 		cfg, err := New("https://api.example.com",
-			JWTBearerAssertion(jwtAssertion),
-			AuthTokenURL("https://login.cf.example.com", "https://token.cf.example.com"))
+			JWTBearerAssertion(validAssertion),
+			AuthTokenURL(uaaURL, uaaURL))
 		require.NoError(t, err)
 
 		src, err := cfg.CreateOAuth2TokenSource(context.Background())
 		require.NoError(t, err)
-		jwtSrc, ok := src.(*jwt.JWTAssertionTokenSource)
-		require.True(t, ok, "expected *jwt.JWTAssertionTokenSource, got %T", src)
-		require.Equal(t, "https://token.cf.example.com/oauth/token", jwtSrc.TokenURL)
+		_, isAssertionSrc := src.(*jwt.JWTAssertionTokenSource)
+		require.False(t, isAssertionSrc, "after eager exchange the long-lived source must not be the assertion source")
+
+		token, err := src.Token()
+		require.NoError(t, err)
+		require.NotEmpty(t, token.AccessToken)
+		require.Equal(t, "barfoo", token.RefreshToken)
 	})
 
-	t.Run("TokenURL has login_hint when origin is set", func(t *testing.T) {
+	t.Run("caches access token when UAA does not issue a refresh_token", func(t *testing.T) {
+		var hits []string
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hits = append(hits, r.Method+" "+r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"access_token":"a","token_type":"bearer","expires_in":600}`)
+		}))
+		defer ts.Close()
+
 		cfg, err := New("https://api.example.com",
-			JWTBearerAssertion(jwtAssertion),
-			Origin("my-idp"),
-			AuthTokenURL("https://login.cf.example.com", "https://token.cf.example.com"))
+			JWTBearerAssertion(validAssertion),
+			AuthTokenURL(ts.URL, ts.URL))
+		require.NoError(t, err)
+		require.Equal(t, []string{"POST /oauth/token"}, hits, "eager exchange should hit UAA exactly once at config-init time")
+
+		src, err := cfg.CreateOAuth2TokenSource(context.Background())
+		require.NoError(t, err)
+		// Cached token is reused; UAA must not be called again.
+		token, err := src.Token()
+		require.NoError(t, err)
+		require.Equal(t, "a", token.AccessToken)
+		token, err = src.Token()
+		require.NoError(t, err)
+		require.Equal(t, "a", token.AccessToken)
+		require.Equal(t, []string{"POST /oauth/token", "POST /oauth/token"}, hits,
+			"the second CreateOAuth2TokenSource performs a fresh exchange; "+
+				"subsequent Token() calls on the cached source must not re-hit UAA")
+	})
+
+	t.Run("returns diagnostic when cached access token expires without a refresh_token", func(t *testing.T) {
+		// expires_in:1 puts the token within oauth2's 10-second expiry buffer,
+		// so ReuseTokenSource treats it as already-expired and falls through
+		// to the diagnostic source on the very next Token() call.
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"access_token":"a","token_type":"bearer","expires_in":1}`)
+		}))
+		defer ts.Close()
+
+		cfg, err := New("https://api.example.com",
+			JWTBearerAssertion(validAssertion),
+			AuthTokenURL(ts.URL, ts.URL))
 		require.NoError(t, err)
 
 		src, err := cfg.CreateOAuth2TokenSource(context.Background())
 		require.NoError(t, err)
-		jwtSrc, ok := src.(*jwt.JWTAssertionTokenSource)
-		require.True(t, ok, "expected *jwt.JWTAssertionTokenSource, got %T", src)
-		require.Contains(t, jwtSrc.TokenURL, "https://token.cf.example.com/oauth/token")
-		require.Contains(t, jwtSrc.TokenURL, "login_hint")
-		require.Contains(t, jwtSrc.TokenURL, "my-idp")
+		_, err = src.Token()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no refresh token was issued by UAA")
+	})
+
+	t.Run("invalid assertion fails at config.New time", func(t *testing.T) {
+		// UAA rejects the exchange. config.New must surface the error
+		// rather than deferring it to the first authenticated API call.
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, `{"error":"invalid_grant","error_description":"assertion expired"}`)
+		}))
+		defer ts.Close()
+
+		_, err := New("https://api.example.com",
+			JWTBearerAssertion(validAssertion),
+			AuthTokenURL(ts.URL, ts.URL))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "jwt-bearer assertion exchange failed")
 	})
 }

--- a/internal/jwt/token.go
+++ b/internal/jwt/token.go
@@ -180,9 +180,16 @@ func (s *JWTAssertionTokenSource) Token() (*oauth2.Token, error) {
 		TokenType:    wire.TokenType,
 		RefreshToken: wire.RefreshToken,
 	}
-	if wire.ExpiresIn > 0 {
-		token.Expiry = time.Now().Add(time.Duration(wire.ExpiresIn) * time.Second)
+	// expires_in is required: without it, oauth2.Token.Expiry stays zero, and
+	// oauth2.Token.Valid() treats a zero Expiry as "valid forever". That would
+	// defeat both the refresh-token handoff (the cached token would never be
+	// considered expired, so refresh would never run) and the no-refresh-token
+	// diagnostic (which fires only when the cached token expires). Treat a
+	// missing or non-positive expires_in as a malformed response.
+	if wire.ExpiresIn <= 0 {
+		return nil, fmt.Errorf("token response missing or invalid expires_in")
 	}
+	token.Expiry = time.Now().Add(time.Duration(wire.ExpiresIn) * time.Second)
 	return token, nil
 }
 

--- a/internal/jwt/token.go
+++ b/internal/jwt/token.go
@@ -162,12 +162,28 @@ func (s *JWTAssertionTokenSource) Token() (*oauth2.Token, error) {
 		return nil, fmt.Errorf("token request failed: %s", body)
 	}
 
-	var token oauth2.Token
-	err = json.Unmarshal(body, &token)
-	if err != nil {
+	// UAA's documented jwt-bearer response uses snake_case fields and an
+	// expires_in (seconds) field, neither of which oauth2.Token's JSON tags
+	// map. Decode into a wire-format struct and build the oauth2.Token so
+	// Expiry and RefreshToken are populated correctly.
+	var wire struct {
+		AccessToken  string `json:"access_token"`
+		TokenType    string `json:"token_type"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int64  `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &wire); err != nil {
 		return nil, fmt.Errorf("token unmarshal error: %w", err)
 	}
-	return &token, nil
+	token := &oauth2.Token{
+		AccessToken:  wire.AccessToken,
+		TokenType:    wire.TokenType,
+		RefreshToken: wire.RefreshToken,
+	}
+	if wire.ExpiresIn > 0 {
+		token.Expiry = time.Now().Add(time.Duration(wire.ExpiresIn) * time.Second)
+	}
+	return token, nil
 }
 
 // validateJWTTokenFormat checks if the provided JWT token has a valid format.

--- a/internal/jwt/token_test.go
+++ b/internal/jwt/token_test.go
@@ -169,4 +169,27 @@ func TestTokenSource(t *testing.T) {
 		// Expiry should be roughly now + 3600s (allow a generous window for slow CI).
 		require.WithinDuration(t, before.Add(3600*time.Second), token.Expiry, 10*time.Second)
 	})
+	t.Run("Test missing expires_in is rejected", func(t *testing.T) {
+		// Without expires_in, oauth2.Token.Expiry would be zero and Valid() would
+		// treat the token as never-expiring — defeating both the refresh-token
+		// handoff and the no-refresh-token diagnostic. Such a response must error.
+		ts := mockServer(200, `{"access_token":"`+validToken+`","token_type":"bearer","refresh_token":"r-token"}`)
+		defer ts.Close()
+		src := &JWTAssertionTokenSource{
+			Assertion: validAssertionToken,
+			TokenURL:  ts.URL,
+		}
+		_, err := src.Token()
+		require.EqualError(t, err, "token response missing or invalid expires_in")
+	})
+	t.Run("Test zero expires_in is rejected", func(t *testing.T) {
+		ts := mockServer(200, `{"access_token":"`+validToken+`","token_type":"bearer","expires_in":0,"refresh_token":"r-token"}`)
+		defer ts.Close()
+		src := &JWTAssertionTokenSource{
+			Assertion: validAssertionToken,
+			TokenURL:  ts.URL,
+		}
+		_, err := src.Token()
+		require.EqualError(t, err, "token response missing or invalid expires_in")
+	})
 }

--- a/internal/jwt/token_test.go
+++ b/internal/jwt/token_test.go
@@ -152,4 +152,21 @@ func TestTokenSource(t *testing.T) {
 		_, err := src.Token()
 		require.EqualError(t, err, "client_id is required when using client assertion")
 	})
+	t.Run("Test response parsing populates Expiry and RefreshToken", func(t *testing.T) {
+		ts := mockServer(200, `{"access_token":"`+validToken+`","token_type":"bearer","expires_in":3600,"refresh_token":"r-token"}`)
+		defer ts.Close()
+		src := &JWTAssertionTokenSource{
+			Assertion: validAssertionToken,
+			TokenURL:  ts.URL,
+		}
+		before := time.Now()
+		token, err := src.Token()
+		require.NoError(t, err)
+		require.Equal(t, validToken, token.AccessToken)
+		require.Equal(t, "bearer", token.TokenType)
+		require.Equal(t, "r-token", token.RefreshToken)
+		require.False(t, token.Expiry.IsZero(), "Expiry must be populated from expires_in")
+		// Expiry should be roughly now + 3600s (allow a generous window for slow CI).
+		require.WithinDuration(t, before.Add(3600*time.Second), token.Expiry, 10*time.Second)
+	})
 }


### PR DESCRIPTION
This PR introduces a aligned and hardened flow for the jwt bearer authentication. The implementation aligns the quthentication flow with the existing authentication flow to have a consistent code base for the authentication flows. As an addition it handles possible expires of the token as in the other already existing authentication flows

Closes #509 